### PR TITLE
Partial revert of 7b59e09cf5eecda2029295db10fdc98dfb5dacc3.

### DIFF
--- a/libmariadb/libmariadb.c
+++ b/libmariadb/libmariadb.c
@@ -1713,7 +1713,7 @@ MYSQL *mthd_my_real_connect(MYSQL *mysql, const char *host, const char *user,
         if (mysql->options.extension && mysql->options.extension->async_context &&
              mysql->options.extension->async_context->active)
           break;
-        else if (socket_block(sock, 0) == SOCKET_ERROR)
+        else if (socket_block(sock, 1) == SOCKET_ERROR)
         {
           closesocket(sock);
           continue;


### PR DESCRIPTION
Switching the just opened connection to non-blocking mode
can cause "Lost connection to MySQL server at 'handshake:
reading inital communication packet', system error: 11",
where errno 11 is EAGAIN.

Signed-off-by: Henrik Grubbström grubba@grubba.org
