### PR TITLE
fix compiler cast warnings in unittests

### DIFF
--- a/unittest/libmariadb/connection.c
+++ b/unittest/libmariadb/connection.c
@@ -632,7 +632,7 @@ int test_connection_timeout(MYSQL *my)
     return FAIL;
   }
   elapsed= time(NULL) - start;
-  diag("elapsed: %u", elapsed);
+  diag("elapsed: %lu", (unsigned long)elapsed);
   mysql_close(mysql);
   FAIL_IF(elapsed > 2 * timeout, "timeout ignored")
   return OK;

--- a/unittest/libmariadb/dyncol.c
+++ b/unittest/libmariadb/dyncol.c
@@ -146,7 +146,7 @@ static int create_dyncol_num(MYSQL *mysql)
   diag("---------------__");
   for(i=0; i < 5; i++)
   {
-    diag("%s %d", my_keys[i].str, my_keys[i].length);
+    diag("%s %lu", my_keys[i].str, (unsigned long)my_keys[i].length);
   }
   free(my_keys);
   free(my_vals);
@@ -224,7 +224,7 @@ static int mdev_x1(MYSQL *mysql)
   diag("Columns: %d", unpack_columns);
 
   for (i=0; i < unpack_columns; i++)
-    diag("Key: %s Len: %d", unpack_keys[i].str, unpack_keys[i].length);
+    diag("Key: %s Len: %lu", unpack_keys[i].str, (unsigned long)unpack_keys[i].length);
 
 
   free(unpack_keys);


### PR DESCRIPTION
size_t is not always an unsigned long on all platforms, but for diagnostic
message in a test, it should be fine to cast it this way

addresses these warnings:

unittest/libmariadb/connection.c:635:3: warning: format '%u' expects argument of type 'unsigned int', but argument 2 has type 'time_t' [-Wformat=]
   diag("elapsed: %u", elapsed);

unittest/libmariadb/dyncol.c:149:5: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' [-Wformat=]
     diag("%s %d", my_keys[i].str, my_keys[i].length);

unittest/libmariadb/dyncol.c:227:5: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' [-Wformat=]
     diag("Key: %s Len: %d", unpack_keys[i].str, unpack_keys[i].length);