### PR TITLE
Windows 64-bit fixes:

### DIFF
--- a/include/my_stmt.h
+++ b/include/my_stmt.h
@@ -131,7 +131,7 @@ typedef struct st_mysql_error_info
 
 struct st_mysqlnd_stmt_methods
 {
-  my_bool (*prepare)(const MYSQL_STMT * stmt, const char * const query, unsigned int query_len);
+  my_bool (*prepare)(const MYSQL_STMT * stmt, const char * const query, size_t query_len);
   my_bool (*execute)(const MYSQL_STMT * stmt);
   MYSQL_RES * (*use_result)(const MYSQL_STMT * stmt);
   MYSQL_RES * (*store_result)(const MYSQL_STMT * stmt);
@@ -148,7 +148,7 @@ struct st_mysqlnd_stmt_methods
   my_bool (*refresh_bind_param)(const MYSQL_STMT * stmt);
   my_bool (*bind_result)(const MYSQL_STMT * stmt, const MYSQL_BIND *bind);
   my_bool (*send_long_data)(const MYSQL_STMT * stmt, unsigned int param_num,
-                            const char * const data, unsigned long length);
+                            const char * const data, size_t length);
   MYSQL_RES *(*get_parameter_metadata)(const MYSQL_STMT * stmt);
   MYSQL_RES *(*get_result_metadata)(const MYSQL_STMT * stmt);
   my_ulonglong (*get_last_insert_id)(const MYSQL_STMT * stmt);
@@ -224,7 +224,7 @@ int simple_command(MYSQL *mysql,enum enum_server_command command, const char *ar
  *  function prototypes
  */
 MYSQL_STMT * STDCALL mysql_stmt_init(MYSQL *mysql);
-int STDCALL mysql_stmt_prepare(MYSQL_STMT *stmt, const char *query, unsigned long length);
+int STDCALL mysql_stmt_prepare(MYSQL_STMT *stmt, const char *query, size_t length);
 int STDCALL mysql_stmt_execute(MYSQL_STMT *stmt);
 int STDCALL mysql_stmt_fetch(MYSQL_STMT *stmt);
 int STDCALL mysql_stmt_fetch_column(MYSQL_STMT *stmt, MYSQL_BIND *bind_arg, unsigned int column, unsigned long offset);
@@ -237,7 +237,7 @@ my_bool STDCALL mysql_stmt_bind_result(MYSQL_STMT * stmt, MYSQL_BIND * bnd);
 my_bool STDCALL mysql_stmt_close(MYSQL_STMT * stmt);
 my_bool STDCALL mysql_stmt_reset(MYSQL_STMT * stmt);
 my_bool STDCALL mysql_stmt_free_result(MYSQL_STMT *stmt);
-my_bool STDCALL mysql_stmt_send_long_data(MYSQL_STMT *stmt, unsigned int param_number, const char *data, unsigned long length);
+my_bool STDCALL mysql_stmt_send_long_data(MYSQL_STMT *stmt, unsigned int param_number, const char *data, size_t length);
 MYSQL_RES *STDCALL mysql_stmt_result_metadata(MYSQL_STMT *stmt);
 MYSQL_RES *STDCALL mysql_stmt_param_metadata(MYSQL_STMT *stmt);
 unsigned int STDCALL mysql_stmt_errno(MYSQL_STMT * stmt);

--- a/include/mysql.h
+++ b/include/mysql.h
@@ -425,10 +425,10 @@ void		STDCALL mysql_close(MYSQL *sock);
 int		STDCALL mysql_select_db(MYSQL *mysql, const char *db);
 int		STDCALL mysql_query(MYSQL *mysql, const char *q);
 int		STDCALL mysql_send_query(MYSQL *mysql, const char *q,
-					 unsigned long length);
+					 size_t length);
 my_bool	STDCALL mysql_read_query_result(MYSQL *mysql);
 int		STDCALL mysql_real_query(MYSQL *mysql, const char *q,
-					unsigned long length);
+					 size_t length);
 int		STDCALL mysql_create_db(MYSQL *mysql, const char *DB);
 int		STDCALL mysql_drop_db(MYSQL *mysql, const char *DB);
 int		STDCALL mysql_shutdown(MYSQL *mysql, enum mysql_enum_shutdown_level shutdown_level);
@@ -488,7 +488,7 @@ size_t STDCALL mariadb_convert_string(const char *from, size_t *from_len, CHARSE
                                       char *to, size_t *to_len, CHARSET_INFO *to_cs, int *errorcode);
 int STDCALL mysql_optionsv(MYSQL *mysql,enum mysql_option option, ...); 
 MYSQL_PARAMETERS *STDCALL mysql_get_parameters(void);
-unsigned long STDCALL mysql_hex_string(char *to, const char *from, unsigned long len);
+unsigned long STDCALL mysql_hex_string(char *to, const char *from, size_t len);
 my_socket STDCALL mysql_get_socket(const MYSQL *mysql);
 unsigned int STDCALL mysql_get_timeout_value(const MYSQL *mysql);
 unsigned int STDCALL mysql_get_timeout_value_ms(const MYSQL *mysql);
@@ -542,7 +542,7 @@ int             STDCALL mysql_send_query_start(int *ret, MYSQL *mysql,
 int             STDCALL mysql_send_query_cont(int *ret, MYSQL *mysql, int status);
 int             STDCALL mysql_real_query_start(int *ret, MYSQL *mysql,
                                                const char *q,
-                                               unsigned long length);
+                                               size_t length);
 int             STDCALL mysql_real_query_cont(int *ret, MYSQL *mysql,
                                               int status);
 int             STDCALL mysql_store_result_start(MYSQL_RES **ret, MYSQL *mysql);
@@ -580,7 +580,7 @@ int             STDCALL mysql_read_query_result_start(my_bool *ret,
                                                       MYSQL *mysql);
 int             STDCALL mysql_read_query_result_cont(my_bool *ret,
                                                      MYSQL *mysql, int status);
-int STDCALL mysql_stmt_prepare_start(int *ret, MYSQL_STMT *stmt,const char *query, unsigned long length);
+int STDCALL mysql_stmt_prepare_start(int *ret, MYSQL_STMT *stmt,const char *query, size_t length);
 int STDCALL mysql_stmt_prepare_cont(int *ret, MYSQL_STMT *stmt, int status);
 int STDCALL mysql_stmt_execute_start(int *ret, MYSQL_STMT *stmt);
 int STDCALL mysql_stmt_execute_cont(int *ret, MYSQL_STMT *stmt, int status);
@@ -599,7 +599,7 @@ int STDCALL mysql_stmt_free_result_cont(my_bool *ret, MYSQL_STMT *stmt,
 int STDCALL mysql_stmt_send_long_data_start(my_bool *ret, MYSQL_STMT *stmt,
                                             unsigned int param_number,
                                             const char *data,
-                                            unsigned long len);
+                                            size_t len);
 int STDCALL mysql_stmt_send_long_data_cont(my_bool *ret, MYSQL_STMT *stmt,
                                            int status);
 

--- a/libmariadb/libmariadb.c
+++ b/libmariadb/libmariadb.c
@@ -2004,7 +2004,7 @@ mysql_query(MYSQL *mysql, const char *query)
 */  
 
 int STDCALL
-mysql_send_query(MYSQL* mysql, const char* query, unsigned long length)
+mysql_send_query(MYSQL* mysql, const char* query, size_t length)
 {
   return simple_command(mysql, COM_QUERY, query, length, 1,0);
 }
@@ -2065,7 +2065,7 @@ mysql_read_query_result(MYSQL *mysql)
 }
 
 int STDCALL
-mysql_real_query(MYSQL *mysql, const char *query, unsigned long length)
+mysql_real_query(MYSQL *mysql, const char *query, size_t length)
 {
   DBUG_ENTER("mysql_real_query");
   DBUG_PRINT("enter",("handle: %lx",mysql));
@@ -3206,8 +3206,7 @@ ulong STDCALL mysql_get_client_version(void)
   return MYSQL_VERSION_ID;
 }
 
-ulong STDCALL mysql_hex_string(char *to, const char *from,
-                               unsigned long len)
+ulong STDCALL mysql_hex_string(char *to, const char *from, size_t len)
 {
   char *start= to;
   char hexdigits[]= "0123456789ABCDEF";

--- a/libmariadb/ma_io.c
+++ b/libmariadb/ma_io.c
@@ -87,7 +87,7 @@ MA_FILE *ma_open(const char *location, const char *mode, MYSQL *mysql)
       my_free(w_filename);
       return NULL;
     }
-    len= strlen(mode);
+    len= (int)strlen(mode);
     if (!(w_mode= (wchar_t *)my_malloc((len + 1) * sizeof(wchar_t), MYF(MY_ZEROFILL))))
     {
       my_set_error(mysql, CR_OUT_OF_MEMORY, SQLSTATE_UNKNOWN, 0);
@@ -213,7 +213,7 @@ char *ma_gets(char *ptr, size_t size, MA_FILE *file)
 
   switch (file->type) {
   case MA_FILE_LOCAL:
-    return fgets(ptr, size, (FILE *)file->ptr);
+    return fgets(ptr, (int)size, (FILE *)file->ptr);
     break;
 #ifdef HAVE_REMOTEIO
   case MA_FILE_REMOTE:

--- a/libmariadb/ma_ssl.c
+++ b/libmariadb/ma_ssl.c
@@ -128,7 +128,7 @@ my_bool ma_pvio_ssl_check_fp(MARIADB_SSL *cssl, const char *fp, const char *fp_l
   if ((cert_fp_len= ma_ssl_get_finger_print(cssl, cert_fp, cert_fp_len)) < 1)
     goto end;
   if (fp)
-    rc= ma_pvio_ssl_compare_fp(cert_fp, cert_fp_len, (char *)fp, strlen(fp));
+    rc= ma_pvio_ssl_compare_fp(cert_fp, cert_fp_len, (char *)fp, (unsigned int)strlen(fp));
   else if (fp_list)
   {
     FILE *fp;
@@ -153,7 +153,7 @@ my_bool ma_pvio_ssl_check_fp(MARIADB_SSL *cssl, const char *fp, const char *fp_l
       if (pos)
         *pos= '\0';
         
-      if (!ma_pvio_ssl_compare_fp(cert_fp, cert_fp_len, buff, strlen(buff)))
+      if (!ma_pvio_ssl_compare_fp(cert_fp, cert_fp_len, buff, (unsigned int)strlen(buff)))
       {
         /* finger print is valid: close file and exit */
         fclose(fp);

--- a/libmariadb/my_charset.c
+++ b/libmariadb/my_charset.c
@@ -1135,19 +1135,19 @@ static void map_charset_name(const char *cs_name, my_bool target_cs, char *buffe
   if (sscanf(cs_name, "UTF%2[0-9]%2[LBE]", digits, endianness))
   {
     /* We should have at least digits. Endianness we write either default(BE), or what we found in the string */
-    ptr= strnmov(ptr, "UTF-", buff_len);
-    ptr= strnmov(ptr, digits, buff_len - (ptr - buffer));
-    ptr= strnmov(ptr, endianness, buff_len - (ptr - buffer));
+    ptr= strnmov(ptr, "UTF-", (uint)buff_len);
+    ptr= strnmov(ptr, digits, (uint)(buff_len - (ptr - buffer)));
+    ptr= strnmov(ptr, endianness, (uint)(buff_len - (ptr - buffer)));
   }
   else
   {
     /* Not our client - copy as is*/
-    ptr= strnmov(ptr, cs_name, buff_len);
+    ptr= strnmov(ptr, cs_name, (uint)buff_len);
   }
 
   if (target_cs)
   {
-    strnmov(ptr, "//TRANSLIT", buff_len - (ptr - buffer));
+    strnmov(ptr, "//TRANSLIT", (uint)(buff_len - (ptr - buffer)));
   }
 }
 /* }}} */

--- a/libmariadb/my_compress.c
+++ b/libmariadb/my_compress.c
@@ -63,7 +63,7 @@ unsigned char *my_compress_alloc(const unsigned char *packet, size_t *len, size_
     my_free(compbuf);
     return 0;
   }
-  swap(ulong,*len,*complen);			/* *len is now packet length */
+  swap(size_t,*len,*complen);			/* *len is now packet length */
   return compbuf;
 }
 

--- a/libmariadb/my_loaddata.c
+++ b/libmariadb/my_loaddata.c
@@ -117,7 +117,7 @@ int mysql_local_infile_read(void *ptr, char * buf, unsigned int buf_len)
     strcpy(info->error_msg, "Error reading file");
     info->error_no = EE_READ;
   }
-  DBUG_RETURN(count);
+  DBUG_RETURN((int)count);
 }
 /* }}} */
 

--- a/libmariadb/my_stmt.c
+++ b/libmariadb/my_stmt.c
@@ -1221,7 +1221,7 @@ my_bool mthd_stmt_get_result_metadata(MYSQL_STMT *stmt)
   DBUG_RETURN(0);
 }
 
-int STDCALL mysql_stmt_prepare(MYSQL_STMT *stmt, const char *query, unsigned long length)
+int STDCALL mysql_stmt_prepare(MYSQL_STMT *stmt, const char *query, size_t length)
 {
   MYSQL *mysql= stmt->mysql; 
   int rc= 1;
@@ -1792,7 +1792,7 @@ MYSQL_ROW_OFFSET STDCALL mysql_stmt_row_seek(MYSQL_STMT *stmt, MYSQL_ROW_OFFSET 
 }
 
 my_bool STDCALL mysql_stmt_send_long_data(MYSQL_STMT *stmt, uint param_number,
-    const char *data, ulong length)
+    const char *data, size_t length)
 {
   DBUG_ENTER("mysql_stmt_send_long_data");
 

--- a/libmariadb/mysql_async.c
+++ b/libmariadb/mysql_async.c
@@ -496,7 +496,7 @@ MK_ASYNC_INTERNAL_BODY(
   r_int)
 }
 int STDCALL
-mysql_real_query_start(int *ret, MYSQL *mysql, const char *stmt_str, unsigned long length)
+mysql_real_query_start(int *ret, MYSQL *mysql, const char *stmt_str, size_t length)
 {
   int res;                                                                    
   struct mysql_async_context *b;                                              
@@ -1414,7 +1414,7 @@ MK_ASYNC_INTERNAL_BODY(
 }
 int STDCALL
 mysql_stmt_prepare_start(int *ret, MYSQL_STMT *stmt, const char *query,
-                         unsigned long length)
+                         size_t length)
 {
 MK_ASYNC_START_BODY(
   mysql_stmt_prepare,
@@ -1718,7 +1718,7 @@ MK_ASYNC_INTERNAL_BODY(
 int STDCALL
 mysql_stmt_send_long_data_start(my_bool *ret, MYSQL_STMT *stmt,
                                 unsigned int param_number,
-                                const char *data, unsigned long length)
+                                const char *data, size_t length)
 {
 MK_ASYNC_START_BODY(
   mysql_stmt_send_long_data,

--- a/libmariadb/net.c
+++ b/libmariadb/net.c
@@ -175,7 +175,7 @@ static my_bool net_realloc(NET *net, size_t length)
     DBUG_RETURN(1);
   }
   net->buff=net->write_pos=buff;
-  net->buff_end=buff+(net->max_packet=pkt_length);
+  net->buff_end=buff+(net->max_packet=(unsigned long)pkt_length);
   DBUG_RETURN(0);
 }
 
@@ -211,7 +211,7 @@ static my_bool net_check_socket_status(my_socket sock)
   FD_ZERO(&sfds);
   FD_SET(sock, &sfds);
 
-  res= select(sock + 1, &sfds, NULL, NULL, &tv);
+  res= select((int)sock + 1, &sfds, NULL, NULL, &tv);
   if (res > 0 && FD_ISSET(sock, &sfds))
     return TRUE;
   return FALSE;
@@ -659,7 +659,7 @@ ulong my_net_read(NET *net)
         start= 0;
       }
 
-      net->where_b=buffer_length;
+      net->where_b=(unsigned long)buffer_length;
 
       if ((packet_length = my_real_read(net,(size_t *)&complen)) == packet_error)
         return packet_error;
@@ -674,8 +674,8 @@ ulong my_net_read(NET *net)
       buffer_length+= complen;
     }
     /* set values */
-    net->buf_length= buffer_length;
-    net->remain_in_buf= buffer_length - current;
+    net->buf_length= (unsigned long)buffer_length;
+    net->remain_in_buf= (unsigned long)(buffer_length - current);
     net->read_pos= net->buff + start + 4;
     len= current - start - 4;
     if (is_multi_packet)

--- a/libmariadb/secure/ma_schannel.h
+++ b/libmariadb/secure/ma_schannel.h
@@ -86,7 +86,7 @@ my_bool ma_schannel_verify_certs(SC_CTX *sctx, DWORD dwCertFlags);
 size_t ma_schannel_write_encrypt(MARIADB_PVIO *pvio,
                                  uchar *WriteBuffer,
                                  size_t WriteBufferSize);
- size_t ma_schannel_read_decrypt(MARIADB_PVIO *pvio,
+ SECURITY_STATUS ma_schannel_read_decrypt(MARIADB_PVIO *pvio,
                                  PCredHandle phCreds,
                                  CtxtHandle * phContext,
                                  DWORD *DecryptLength,

--- a/libmariadb/secure/schannel.c
+++ b/libmariadb/secure/schannel.c
@@ -22,7 +22,7 @@
 #pragma comment (lib, "crypt32.lib")
 #pragma comment (lib, "secur32.lib")
 
-#define VOID void
+//#define VOID void
 
 extern my_bool ma_ssl_initialized;
 
@@ -107,7 +107,7 @@ static int ssl_thread_init()
     0  success
     1  error
 */
-int ma_ssl_start(char *errmsg, size_t errmsg_len, int count, va_list list)
+int ma_ssl_start(char *errmsg, size_t errmsg_len)
 {
   if (!ma_ssl_initialized)
   {
@@ -158,7 +158,6 @@ static int ma_ssl_set_client_certs(MARIADB_SSL *cssl)
   if (cafile)
   {
     HCERTSTORE myCS= NULL;
-    char szName[64];
 
     if (!(sctx->client_ca_ctx = ma_schannel_create_cert_context(pvio, cafile)))
       goto end;
@@ -216,7 +215,6 @@ end:
 /* {{{ void *ma_ssl_init(MARIADB_SSL *cssl, MYSQL *mysql) */
 void *ma_ssl_init(MYSQL *mysql)
 {
-  int verify;
   SC_CTX *sctx= NULL;
 
   pthread_mutex_lock(&LOCK_schannel_config);
@@ -333,7 +331,7 @@ size_t ma_ssl_read(MARIADB_SSL *cssl, const uchar* buffer, size_t length)
   MARIADB_PVIO *pvio= sctx->mysql->net.pvio;
   DWORD dlength= -1;
 
-  ma_schannel_read_decrypt(pvio, &sctx->CredHdl, &sctx->ctxt, &dlength, (uchar *)buffer, length);
+  ma_schannel_read_decrypt(pvio, &sctx->CredHdl, &sctx->ctxt, &dlength, (uchar *)buffer, (DWORD)length);
   return dlength;
 }
 
@@ -472,7 +470,7 @@ unsigned int ma_ssl_get_finger_print(MARIADB_SSL *cssl, unsigned char *fp, unsig
   SC_CTX *sctx= (SC_CTX *)cssl->ssl;
   PCCERT_CONTEXT pRemoteCertContext = NULL;
   if (QueryContextAttributes(&sctx->ctxt, SECPKG_ATTR_REMOTE_CERT_CONTEXT, (PVOID)&pRemoteCertContext) != SEC_E_OK)
-    return NULL;
+    return 0;
   CertGetCertificateContextProperty(pRemoteCertContext, CERT_HASH_PROP_ID, fp, (DWORD *)&len);
   return len;
 }

--- a/plugins/auth/dialog.c
+++ b/plugins/auth/dialog.c
@@ -168,7 +168,7 @@ static int auth_dialog_open(MYSQL_PLUGIN_VIO *vio, MYSQL *mysql)
       response= mysql->passwd;
     }
     if (!response ||
-        vio->write_packet(vio, response, strlen(response) + 1))
+        vio->write_packet(vio, response, (int)strlen(response) + 1))
       return CR_ERROR;
 
     first_loop= FALSE;

--- a/plugins/auth/mariadb_cleartext.c
+++ b/plugins/auth/mariadb_cleartext.c
@@ -48,7 +48,7 @@ static int clear_password_auth_client(MYSQL_PLUGIN_VIO *vio, MYSQL *mysql)
     return CR_ERROR;
 
   /* write password including terminating zero character */
-  return vio->write_packet(vio, (const unsigned char *) mysql->passwd, strlen(mysql->passwd) + 1) ?
+  return vio->write_packet(vio, (const unsigned char *) mysql->passwd, (int)strlen(mysql->passwd) + 1) ?
          CR_ERROR : CR_OK;
 }
 /* }}} */

--- a/plugins/pvio/pvio_npipe.c
+++ b/plugins/pvio/pvio_npipe.c
@@ -112,7 +112,7 @@ size_t pvio_npipe_read(MARIADB_PVIO *pvio, uchar *buffer, size_t length)
 
   cpipe= (struct st_pvio_npipe *)pvio->data;
 
-  if (ReadFile(cpipe->pipe, (LPVOID)buffer, length, &dwRead, &cpipe->overlapped))
+  if (ReadFile(cpipe->pipe, (LPVOID)buffer, (DWORD)length, &dwRead, &cpipe->overlapped))
   {
     r= (size_t)dwRead;
     goto end;
@@ -137,7 +137,7 @@ size_t pvio_npipe_write(MARIADB_PVIO *pvio, const uchar *buffer, size_t length)
 
   cpipe= (struct st_pvio_npipe *)pvio->data;
 
-  if (WriteFile(cpipe->pipe, buffer, length, &dwWrite, &cpipe->overlapped))
+  if (WriteFile(cpipe->pipe, buffer, (DWORD)length, &dwWrite, &cpipe->overlapped))
   {
     r= (size_t)dwWrite;
     goto end;

--- a/plugins/pvio/pvio_socket.c
+++ b/plugins/pvio/pvio_socket.c
@@ -313,7 +313,7 @@ size_t pvio_socket_async_read(MARIADB_PVIO *pvio, uchar *buffer, size_t length)
 #ifndef _WIN32
   r= recv(csock->socket,(void *)buffer, length, read_flags);
 #else
-  r= recv(csock->socket, (char *)buffer, length, 0);
+  r= recv(csock->socket, (char *)buffer, (int)length, 0);
 #endif
   return r;
 }
@@ -359,7 +359,7 @@ size_t pvio_socket_async_write(MARIADB_PVIO *pvio, const uchar *buffer, size_t l
 #ifndef WIN32
   r= send(csock->socket, buffer, length, write_flags);
 #else
-  r= send(csock->socket, buffer, length, 0);
+  r= send(csock->socket, buffer, (int)length, 0);
 #endif
   return r;
 }
@@ -768,7 +768,7 @@ my_bool pvio_socket_connect(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo)
       {
         for (bres= bind_res; bres; bres= bres->ai_next)
         {
-          if (!(rc= bind(csock->socket, bres->ai_addr, bres->ai_addrlen)))
+          if (!(rc= bind(csock->socket, bres->ai_addr, (int)bres->ai_addrlen)))
             break;
         }
         if (rc)
@@ -778,7 +778,7 @@ my_bool pvio_socket_connect(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo)
         }
       }
 
-      rc= pvio_socket_connect_sync_or_async(pvio, save_res->ai_addr, save_res->ai_addrlen);
+      rc= pvio_socket_connect_sync_or_async(pvio, save_res->ai_addr, (uint)save_res->ai_addrlen);
       if (!rc)
       {
         MYSQL *mysql= pvio->mysql;
@@ -921,7 +921,7 @@ my_bool pvio_socket_is_alive(MARIADB_PVIO *pvio)
   FD_ZERO(&sfds);
   FD_SET(csock->socket, &sfds);
 
-  res= select(csock->socket + 1, &sfds, NULL, NULL, &tv);
+  res= select((int)+csock->socket + 1, &sfds, NULL, NULL, &tv);
   if (res > 0 && FD_ISSET(csock->socket, &sfds))
     return TRUE;
   return FALSE;

--- a/plugins/trace/trace_example.c
+++ b/plugins/trace/trace_example.c
@@ -124,7 +124,7 @@ static TRACE_INFO *get_trace_info(unsigned long thread_id)
     if (info->thread_id == thread_id)
       return info;
     else
-      info= info->next;
+      info= (TRACE_INFO *)info->next;
   }
 
   if (!(info= (TRACE_INFO *)calloc(sizeof(TRACE_INFO), 1)))
@@ -149,7 +149,7 @@ static void delete_trace_info(unsigned long thread_id)
       if (last)
         last->next= current->next;
       else
-        trace_info= current->next;
+        trace_info= (TRACE_INFO *)current->next;
       if (current->command)
         free(current->command);
       if (current->db)
@@ -161,7 +161,7 @@ static void delete_trace_info(unsigned long thread_id)
       free(current);
     }
     last= current;
-    current= current->next;
+    current= (TRACE_INFO *)current->next;
   }
 
 }
@@ -213,7 +213,7 @@ static int trace_deinit()
   while(trace_info)
   {
     printf("Warning: Connection for thread %lu not properly closed\n", trace_info->thread_id);
-    trace_info= trace_info->next;
+    trace_info= (TRACE_INFO *)trace_info->next;
   }
   register_callback(FALSE, trace_callback);
   return 0;

--- a/unittest/libmariadb/charset.c
+++ b/unittest/libmariadb/charset.c
@@ -322,11 +322,11 @@ static int test_ps_i18n(MYSQL *mysql)
   memset(bind_array, '\0', sizeof(bind_array));
   bind_array[0].buffer_type= MYSQL_TYPE_STRING;
   bind_array[0].buffer= (void *) koi8;
-  bind_array[0].buffer_length= strlen(koi8);
+  bind_array[0].buffer_length= (unsigned long)strlen(koi8);
 
   bind_array[1].buffer_type= MYSQL_TYPE_STRING;
   bind_array[1].buffer= (void *) koi8;
-  bind_array[1].buffer_length= strlen(koi8);
+  bind_array[1].buffer_length= (unsigned long)strlen(koi8);
 
   stmt= mysql_stmt_init(mysql);
   check_stmt_rc(rc, stmt);
@@ -393,11 +393,11 @@ static int test_ps_i18n(MYSQL *mysql)
   /* this data must be converted */
   bind_array[0].buffer_type= MYSQL_TYPE_STRING;
   bind_array[0].buffer= (void *) koi8;
-  bind_array[0].buffer_length= strlen(koi8);
+  bind_array[0].buffer_length= (unsigned long)strlen(koi8);
 
   bind_array[1].buffer_type= MYSQL_TYPE_STRING;
   bind_array[1].buffer= (void *) koi8;
-  bind_array[1].buffer_length= strlen(koi8);
+  bind_array[1].buffer_length= (unsigned long)strlen(koi8);
 
   mysql_stmt_bind_param(stmt, bind_array);
 
@@ -408,11 +408,11 @@ static int test_ps_i18n(MYSQL *mysql)
   /* this data must not be converted */
   bind_array[0].buffer_type= MYSQL_TYPE_BLOB;
   bind_array[0].buffer= (void *) cp1251;
-  bind_array[0].buffer_length= strlen(cp1251);
+  bind_array[0].buffer_length= (unsigned long)strlen(cp1251);
 
   bind_array[1].buffer_type= MYSQL_TYPE_BLOB;
   bind_array[1].buffer= (void *) cp1251;
-  bind_array[1].buffer_length= strlen(cp1251);
+  bind_array[1].buffer_length= (unsigned long)strlen(cp1251);
 
   mysql_stmt_bind_param(stmt, bind_array);
 

--- a/unittest/libmariadb/cursor.c
+++ b/unittest/libmariadb/cursor.c
@@ -478,7 +478,7 @@ static int test_bug10794(MYSQL *mysql)
   {
     id_val= (i+1)*10;
     sprintf(a, "a%d", i);
-    a_len= strlen(a); /* safety against broken sprintf */
+    a_len= (unsigned long)strlen(a); /* safety against broken sprintf */
     rc= mysql_stmt_execute(stmt);
     check_stmt_rc(rc, stmt);
   }
@@ -728,7 +728,7 @@ static int test_bug11656(MYSQL *mysql)
   {
     my_bind[i].buffer_type= MYSQL_TYPE_STRING;
     my_bind[i].buffer= (uchar* *)&buf[i];
-    my_bind[i].buffer_length= strlen(buf[i]);
+    my_bind[i].buffer_length= (unsigned long)strlen(buf[i]);
   }
   rc= mysql_stmt_bind_param(stmt, my_bind);
   check_stmt_rc(rc, stmt);

--- a/unittest/libmariadb/logs.c
+++ b/unittest/libmariadb/logs.c
@@ -61,7 +61,7 @@ static int test_logs(MYSQL *mysql)
   MYSQL_STMT *stmt;
   MYSQL_BIND my_bind[2];
   char       data[255];
-  ulong      length;
+  size_t     length;
   int        rc;
   short      id;
 

--- a/unittest/libmariadb/misc.c
+++ b/unittest/libmariadb/misc.c
@@ -630,7 +630,7 @@ static int test_wl4166_4(MYSQL *mysql)
 
   bind_array[1].buffer_type= MYSQL_TYPE_STRING;
   bind_array[1].buffer= (void *) koi8;
-  bind_array[1].buffer_length= strlen(koi8);
+  bind_array[1].buffer_length= (unsigned long)strlen(koi8);
 
   stmt= mysql_stmt_init(mysql);
   check_stmt_rc(rc, stmt);
@@ -933,7 +933,7 @@ static int test_connect_attrs(MYSQL *my)
   mysql_options(mysql, MYSQL_OPT_CONNECT_ATTR_DELETE, "foo1");
   mysql_options(mysql, MYSQL_OPT_CONNECT_ATTR_DELETE, "foo2");
 
-  len= mysql->options.extension->connect_attrs_len;
+  len= (int)mysql->options.extension->connect_attrs_len;
 
   mysql_close(mysql);
 

--- a/unittest/libmariadb/my_test.h
+++ b/unittest/libmariadb/my_test.h
@@ -50,6 +50,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define MAX_TEST_QUERY_LENGTH 300 /* MAX QUERY BUFFER LENGTH */
 
+/* prevent warnings on Win64 by using STMT_LEN instead of strlen */
+#define STMT_LEN(A) (unsigned long)strlen((A))
+
 #define check_mysql_rc(rc, mysql) \
 if (rc)\
 {\
@@ -195,7 +198,7 @@ int my_stmt_result(MYSQL *mysql, const char *buff)
 
   stmt= mysql_stmt_init(mysql);
 
-  rc= mysql_stmt_prepare(stmt, buff, strlen(buff));
+  rc= mysql_stmt_prepare(stmt, buff, (unsigned long)strlen(buff));
   FAIL_IF(rc, mysql_stmt_error(stmt));
 
   rc= mysql_stmt_execute(stmt);

--- a/unittest/libmariadb/ps_bugs.c
+++ b/unittest/libmariadb/ps_bugs.c
@@ -613,7 +613,7 @@ static int test_bug1500(MYSQL *mysql)
   data= "Dogs";
   my_bind[0].buffer_type= MYSQL_TYPE_STRING;
   my_bind[0].buffer= (void *) data;
-  my_bind[0].buffer_length= strlen(data);
+  my_bind[0].buffer_length= (unsigned long)strlen(data);
   my_bind[0].is_null= 0;
   my_bind[0].length= 0;
 
@@ -842,7 +842,7 @@ static int test_bug1664(MYSQL *mysql)
 
     my_bind[0].buffer_type= MYSQL_TYPE_STRING;
     my_bind[0].buffer= (void *)str_data;
-    my_bind[0].buffer_length= strlen(str_data);
+    my_bind[0].buffer_length= (unsigned long)strlen(str_data);
 
     my_bind[1].buffer= (void *)&int_data;
     my_bind[1].buffer_type= MYSQL_TYPE_LONG;
@@ -1642,7 +1642,7 @@ static int test_ps_conj_select(MYSQL *mysql)
   check_stmt_rc(rc, stmt);
   int_data= 1;
   strcpy(str_data, "hh");
-  str_length= strlen(str_data);
+  str_length= (unsigned long)strlen(str_data);
 
   rc= mysql_stmt_execute(stmt);
   check_stmt_rc(rc, stmt);
@@ -1882,7 +1882,7 @@ static int test_ps_query_cache(MYSQL *mysql)
     check_stmt_rc(rc, stmt);
     p_int_data= 1;
     strcpy(p_str_data, "hh");
-    p_str_length= strlen(p_str_data);
+    p_str_length= (unsigned long)strlen(p_str_data);
 
     memset(r_bind, '\0', sizeof(r_bind));
     r_bind[0].buffer_type= MYSQL_TYPE_LONG;
@@ -1934,7 +1934,7 @@ static int test_ps_query_cache(MYSQL *mysql)
 
     /* now modify parameter values and see qcache hits */
     strcpy(p_str_data, "ii");
-    p_str_length= strlen(p_str_data);
+    p_str_length= (unsigned long)strlen(p_str_data);
     rc= mysql_stmt_execute(stmt);
     check_stmt_rc(rc, stmt);
     test_ps_query_cache_result(1, "hh", 2, 1, "ii", 2, 2, "ii", 2);
@@ -2124,7 +2124,7 @@ static int test_bug3796(MYSQL *mysql)
   memset(my_bind, '\0', sizeof(my_bind));
   my_bind[0].buffer_type= MYSQL_TYPE_STRING;
   my_bind[0].buffer= (void *) concat_arg0;
-  my_bind[0].buffer_length= strlen(concat_arg0);
+  my_bind[0].buffer_length= (unsigned long)strlen(concat_arg0);
 
   mysql_stmt_bind_param(stmt, my_bind);
 

--- a/win-iconv/win_iconv.c
+++ b/win-iconv/win_iconv.c
@@ -1089,7 +1089,7 @@ must_use_null_useddefaultchar(int codepage)
 static char *
 strrstr(const char *str, const char *token)
 {
-    int len = strlen(token);
+    size_t len = strlen(token);
     const char *p = str + strlen(str);
 
     while (str <= --p)


### PR DESCRIPTION
changed type of length parameter in mysql_stmt_prepare,
mysql_real_query, mysql_stmt_send_long_data (incl. async _start
functions) from unsigned long to size_t.
Fixed warnings