### PR TITLE
Fix string conversion of timestamps containing microseconds

### DIFF
--- a/libmariadb/ma_stmt_codec.c
+++ b/libmariadb/ma_stmt_codec.c
@@ -874,21 +874,31 @@ void ps_fetch_datetime(MYSQL_BIND *r_param, const MYSQL_FIELD * field,
       break;
     case MYSQL_TYPE_TIME:
       length= sprintf(dtbuffer, "%s%02u:%02u:%02u", (tm.neg ? "-" : ""), tm.hour, tm.minute, tm.second);
-      if (tm.second_part)
+      if (field->decimals)
       {
-        char helper[16];
-        sprintf(helper, ".%%0%du", field->decimals);
-        length+= sprintf(dtbuffer + length, helper, tm.second_part);
+        char microseconds[16];
+		sprintf(microseconds, ".%06u", tm.second_part);
+		if (field->decimals < 6)
+		{
+			microseconds[field->decimals+1] = '\0';
+		}
+		strcat(dtbuffer + length, microseconds);
+        length+= strlen(microseconds);
       }
       break;
     case MYSQL_TYPE_DATETIME:
     case MYSQL_TYPE_TIMESTAMP:
       length= sprintf(dtbuffer, "%04u-%02u-%02u %02u:%02u:%02u", tm.year, tm.month, tm.day, tm.hour, tm.minute, tm.second);
-      if (tm.second_part)
+      if (field->decimals)
       {
-        char helper[16];
-        sprintf(helper, ".%%0%du", field->decimals);
-        length+= sprintf(dtbuffer + length, helper, tm.second_part);
+        char microseconds[16];
+		sprintf(microseconds, ".%06u", tm.second_part);
+		if (field->decimals < 6)
+		{
+			microseconds[field->decimals+1] = '\0';
+		}
+		strcat(dtbuffer + length, microseconds);
+        length+= strlen(microseconds);
       }
       break;
     default:

--- a/libmariadb/ma_stmt_codec.c
+++ b/libmariadb/ma_stmt_codec.c
@@ -877,12 +877,12 @@ void ps_fetch_datetime(MYSQL_BIND *r_param, const MYSQL_FIELD * field,
       if (field->decimals)
       {
         char microseconds[16];
-		sprintf(microseconds, ".%06u", tm.second_part);
-		if (field->decimals < 6)
-		{
-			microseconds[field->decimals+1] = '\0';
-		}
-		strcat(dtbuffer + length, microseconds);
+        sprintf(microseconds, ".%06u", tm.second_part);
+        if (field->decimals < 6)
+        {
+          microseconds[field->decimals+1] = '\0';
+        }
+        strcat(dtbuffer + length, microseconds);
         length+= strlen(microseconds);
       }
       break;
@@ -892,12 +892,12 @@ void ps_fetch_datetime(MYSQL_BIND *r_param, const MYSQL_FIELD * field,
       if (field->decimals)
       {
         char microseconds[16];
-		sprintf(microseconds, ".%06u", tm.second_part);
-		if (field->decimals < 6)
-		{
-			microseconds[field->decimals+1] = '\0';
-		}
-		strcat(dtbuffer + length, microseconds);
+        sprintf(microseconds, ".%06u", tm.second_part);
+        if (field->decimals < 6)
+        {
+          microseconds[field->decimals+1] = '\0';
+        }
+        strcat(dtbuffer + length, microseconds);
         length+= strlen(microseconds);
       }
       break;


### PR DESCRIPTION
ps_fetch_datetime() does not work for DATETIME(n) fields where n is between 1 and 5.

for example, when DATETIME(3) is used for millisecond resolution, the current version sprintf()s the first 3 digits of the microsecond field, but this yields a wrong output, when there are leading zeroes (see examples below).

Test values, type DATETIME(3):
2016-03-09 07:51:49.000
2016-03-09 07:51:49.001
2016-03-09 07:51:49.010

ps_fetch_datetime() output:
2016-03-09 07:51:49
2016-03-09 07:51:49.1000
2016-03-09 07:51:49.10000
