### PR TITLE
Prevent crash on uninitialized variable

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -1922,7 +1922,7 @@ get_info:
   pos=(uchar*) mysql->net.read_pos;
   if ((field_count= net_field_length(&pos)) == 0)
   {
-    size_t item_len;
+    size_t item_len = 0;
     mysql->affected_rows= net_field_length_ll(&pos);
     mysql->insert_id=	  net_field_length_ll(&pos);
     mysql->server_status=uint2korr(pos); 


### PR DESCRIPTION
Hello.
This small PR is to fix crash on referenced, but uninitialized variable. This prevents crash of the code
if (mysql_query(con, "INSERT INTO `test`.`t1` (`Qwe`) VALUES ('Привет');")) {
        finish_with_error(con);
    }
on line 1939 of this file.
