### PR TITLE
Destroy THR_LOCK_lock mutex

### DIFF
--- a/libmariadb/my_init.c
+++ b/libmariadb/my_init.c
@@ -161,9 +161,6 @@ Voluntary context switches %ld, Involuntary context switches %ld\n",
 #endif
   }
 #ifdef THREAD
-  pthread_mutex_destroy(&THR_LOCK_malloc);
-  pthread_mutex_destroy(&THR_LOCK_open);
-  pthread_mutex_destroy(&THR_LOCK_net);
   DBUG_END();				/* Must be done before my_thread_end */
   my_thread_end();
   my_thread_global_end();

--- a/libmariadb/my_thr_init.c
+++ b/libmariadb/my_thr_init.c
@@ -102,6 +102,10 @@ void my_thread_global_end(void)
 #ifdef HAVE_OPENSSL
   pthread_mutex_destroy(&LOCK_ssl_config);
 #endif
+  pthread_mutex_destroy(&THR_LOCK_malloc);
+  pthread_mutex_destroy(&THR_LOCK_open);
+  pthread_mutex_destroy(&THR_LOCK_lock);
+  pthread_mutex_destroy(&THR_LOCK_net);
 }
 
 static long thread_id=0;


### PR DESCRIPTION
Changes:
- Destroy THR_LOCK_lock mutex in my_thread_global_end()
- Destroy all thread related mutexes in common place

Description:
Problem found using Application Verifier tool from Microsoft.
VERIFIER STOP 00000211: pid 0x864: Critical section is already initialized.

Mutex THR_LOCK_lock is not properly destroyed in my_end (which calls 
my_thread_global_end()), so in case we have connected to database twice
in single application, we are trying to initialize THR_LOCK_lock again 
in my_thread_global_init(), when it is already initialized and not destroyed
from previous connect.

Also I have moved destroying of mutexes to the same file, 
where they are initialized.
