### PR TITLE
Add io wait callback for blockin io operations.

### DIFF
--- a/include/mysql.h
+++ b/include/mysql.h
@@ -208,6 +208,7 @@ extern const char *SQLSTATE_UNKNOWN;
     /* MariaDB specific */
     MYSQL_PROGRESS_CALLBACK=5999,
     MYSQL_OPT_NONBLOCK,
+    MYSQL_OPT_IO_WAIT,
     /* MariaDB Connector/C specific */
     MYSQL_DATABASE_DRIVER=7000,
     MARIADB_OPT_SSL_FP,             /* deprecated, use MARIADB_OPT_TLS_PEER_FP instead */
@@ -316,6 +317,7 @@ struct st_mysql_options {
     int (*local_infile_error)(void *, char *, unsigned int);
     void *local_infile_userdata;
     struct st_mysql_options_extension *extension;
+    int (*io_wait)(my_socket handle, my_bool is_read, int timeout);
 };
 
   typedef struct st_mysql {

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -2716,6 +2716,9 @@ mysql_optionsv(MYSQL *mysql,enum mysql_option option, ...)
       }
     mysql->options.extension->async_context= ctxt;
     break;
+  case MYSQL_OPT_IO_WAIT:
+    mysql->options.io_wait = (int(*)(my_socket, bool, int))arg1;
+    break;
   case MYSQL_OPT_MAX_ALLOWED_PACKET:
     if (mysql)
       mysql->options.max_allowed_packet= (unsigned long)(*(size_t *)arg1);
@@ -3035,6 +3038,9 @@ mysql_get_optionv(MYSQL *mysql, enum mysql_option option, void *arg, ...)
   case MYSQL_OPT_NONBLOCK:
     *((my_bool *)arg)= test(mysql->options.extension && mysql->options.extension->async_context);
     break;
+  case MYSQL_OPT_IO_WAIT:
+    *((int(**)(my_socket, my_bool, int))arg) = mysql->options.io_wait;
+  break;
   case MYSQL_OPT_SSL_ENFORCE:
     *((my_bool *)arg)= mysql->options.use_ssl;
     break;

--- a/plugins/pvio/pvio_npipe.c
+++ b/plugins/pvio/pvio_npipe.c
@@ -162,6 +162,13 @@ end:
 
 int pvio_npipe_wait_io_or_timeout(MARIADB_PVIO *pvio, my_bool is_read, int timeout)
 {
+  if (pvio->mysql->options.io_wait != NULL) {
+    HANDLE handle;
+    if (pvio_npipe_get_handle(pvio, &handle))
+      return 0;
+    return pvio->mysql->options.io_wait(handle, is_read, timeout);
+  }
+
   int r= -1;
   DWORD status;
   int save_error;

--- a/plugins/pvio/pvio_socket.c
+++ b/plugins/pvio/pvio_socket.c
@@ -500,6 +500,13 @@ int pvio_socket_wait_io_or_timeout(MARIADB_PVIO *pvio, my_bool is_read, int time
   if (!pvio || !pvio->data)
     return 0;
 
+  if (pvio->mysql->options.io_wait != NULL) {
+    my_socket handle;
+    if (pvio_socket_get_handle(pvio, &handle))
+      return 0;
+    return pvio->mysql->options.io_wait(handle, is_read, timeout);
+  }
+
   csock= (struct st_pvio_socket *)pvio->data;
   {
 #ifndef _WIN32


### PR DESCRIPTION
Add a io wait callback that will be called instead of base io witing
handlers.

We use mariadb-connector-c for our mariadb/mysql connector [https://github.com/tarantool/mysql](url) for tarantool nosql database [https://github.com/tarantool/tarantool](url).

Mariadb connector uses own internal fiber implementation for async operations and need to special wrap for async api function (_start/_cont), but tarantool already has it own fibers.
I added one option for mysql connection that allowed callback from pvio objects for io polling, in this case standart api calls can be used asynchronously without wrapping, because we will need to call some more methods that already exist in future (ex. for replication from mariadb databases).

Little example can be found at our git repo [https://github.com/tarantool/mysql/blob/master/mysql/driver.c](url)