### PR TITLE
Fix for statement memory alloc:need reset block_num

### DIFF
--- a/libmariadb/my_alloc.c
+++ b/libmariadb/my_alloc.c
@@ -144,6 +144,8 @@ void free_root(MEM_ROOT *root, myf MyFlags)
     root->free->left=root->pre_alloc->size-ALIGN_SIZE(sizeof(USED_MEM));
     root->free->next=0;
   }
+  root->block_num= 4;
+  root->first_block_usage= 0;
   DBUG_VOID_RETURN;
 }
 


### PR DESCRIPTION
When reusing statement for query, result_alloc would become bigger
by calling alloc_root along every query.
because we haven't reset block_num when calling free_root.