### PR TITLE
unittest: ps_bugs - remove compile warning

### DIFF
--- a/unittest/libmariadb/ps_bugs.c
+++ b/unittest/libmariadb/ps_bugs.c
@@ -497,7 +497,7 @@ static int test_bug11183(MYSQL *mysql)
   FAIL_IF(!rc, "Error expected");
 
   mysql_stmt_reset(stmt);
-  FAIL_IF(!mysql_stmt_errno(stmt) == 0, "stmt->error != 0");
+  FAIL_IF(mysql_stmt_errno(stmt) != 0, "stmt->error != 0");
 
   rc= mysql_query(mysql, "create table t1 (a int)");
   check_mysql_rc(rc, mysql);


### PR DESCRIPTION
Using clang-4.0

/home/travis/build/MariaDB/server/libmariadb/unittest/libmariadb/ps_bugs.c:500:11: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
  FAIL_IF(!mysql_stmt_errno(stmt) == 0, "stmt->error != 0");
          ^                       ~~
/home/travis/build/MariaDB/server/libmariadb/unittest/libmariadb/my_test.h:79:5: note: expanded from macro 'FAIL_IF'
if (expr)\
    ^~~~
/home/travis/build/MariaDB/server/libmariadb/unittest/libmariadb/ps_bugs.c:500:11: note: add parentheses after the '!' to evaluate the comparison first
/home/travis/build/MariaDB/server/libmariadb/unittest/libmariadb/ps_bugs.c:500:11: note: add parentheses around left hand side expression to silence this warning