### PR TITLE
Change win32 header references to lower-case as capitalization breaks…

### DIFF
--- a/include/ma_global.h
+++ b/include/ma_global.h
@@ -23,7 +23,7 @@
 
 #ifdef _WIN32
 #include <winsock2.h>
-#include <Windows.h>
+#include <windows.h>
 #include <stdlib.h>
 #define strcasecmp _stricmp
 #define sleep(x) Sleep(1000*(x))

--- a/libmariadb/ma_default.c
+++ b/libmariadb/ma_default.c
@@ -27,7 +27,7 @@
 
 #ifdef _WIN32
 #include <io.h>
-#include "Shlwapi.h"
+#include "shlwapi.h"
 
 static const char *ini_exts[]= {"ini", "cnf", 0};
 #define R_OK 4

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -69,7 +69,7 @@
 #endif
 #include <mysql/client_plugin.h>
 #ifdef _WIN32
-#include "Shlwapi.h"
+#include "shlwapi.h"
 #endif
 
 #define ASYNC_CONTEXT_DEFAULT_STACK_SIZE (4096*15)

--- a/libmariadb/secure/ma_schannel.h
+++ b/libmariadb/secure/ma_schannel.h
@@ -38,7 +38,7 @@
 
 #include <schnlsp.h>
 #undef SECURITY_WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <sspi.h>
 
 #define SC_IO_BUFFER_SIZE 0x4000

--- a/plugins/auth/sspi_client.c
+++ b/plugins/auth/sspi_client.c
@@ -29,7 +29,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define SECURITY_WIN32
 #include <windows.h>
 #include <sspi.h>
-#include <SecExt.h>
+#include <secext.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/plugins/auth/sspi_common.h
+++ b/plugins/auth/sspi_common.h
@@ -29,7 +29,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define SECURITY_WIN32
 #include <windows.h>
 #include <sspi.h>
-#include <SecExt.h>
+#include <secext.h>
 #include <stdarg.h>
 #include <stdio.h>
 


### PR DESCRIPTION
… case-sensitive platforms (found on MinGW-w64)