### PR TITLE
CONC-329: my_bool: change to signed char

### DIFF
--- a/include/ma_global.h
+++ b/include/ma_global.h
@@ -714,7 +714,7 @@ typedef short		int15;	/* Most effective integer 0 <= x <= 32767 */
 typedef char		*my_string; /* String of characters */
 typedef unsigned long	size_s; /* Size of strings (In string-funcs) */
 typedef int		myf;	/* Type of MyFlags in my_funcs */
-typedef char		my_bool; /* Small bool */
+typedef signed char	my_bool; /* Small bool */
 typedef unsigned long long my_ulonglong;
 #if !defined(bool) && !defined(bool_defined) && (!defined(HAVE_BOOL) || !defined(__cplusplus))
 typedef char		bool;	/* Ordinary boolean values 0 1 */

--- a/include/mariadb_dyncol.h
+++ b/include/mariadb_dyncol.h
@@ -225,7 +225,7 @@ void mariadb_dyncol_free(DYNAMIC_COLUMN *str);
 /* conversion of values to 3 base types */
 enum enum_dyncol_func_result
 mariadb_dyncol_val_str(DYNAMIC_STRING *str, DYNAMIC_COLUMN_VALUE *val,
-                       MARIADB_CHARSET_INFO *cs, my_bool quote);
+                       MARIADB_CHARSET_INFO *cs, char quote);
 enum enum_dyncol_func_result
 mariadb_dyncol_val_long(longlong *ll, DYNAMIC_COLUMN_VALUE *val);
 enum enum_dyncol_func_result

--- a/libmariadb/ma_tls.c
+++ b/libmariadb/ma_tls.c
@@ -130,7 +130,7 @@ const char *ma_pvio_tls_get_protocol_version(MARIADB_TLS *ctls)
   return tls_protocol_version[version];
 }
 
-static char ma_hex2int(char c)
+static signed char ma_hex2int(char c)
 {
   if (c >= '0' && c <= '9')
     return c - '0';
@@ -161,7 +161,7 @@ static my_bool ma_pvio_tls_compare_fp(const char *cert_fp,
 
   for(c= (char *)cert_fp; c < cert_fp + cert_fp_len; c++)
   {
-    char d1, d2;
+    signed char d1, d2;
     if (*p == ':')
       p++;
     if (p - fp > (int)fp_len -1)

--- a/unittest/libmariadb/ps.c
+++ b/unittest/libmariadb/ps.c
@@ -2209,7 +2209,7 @@ static int test_bind_negative(MYSQL *mysql)
   my_bind[0].buffer_type= MYSQL_TYPE_LONG;
   my_bind[0].buffer= (void *)&my_val;
   my_bind[0].length= &my_length;
-  my_bind[0].is_null= (char*)&my_null;
+  my_bind[0].is_null= &my_null;
 
   rc= mysql_stmt_bind_param(stmt, my_bind);
   check_stmt_rc(rc, stmt);
@@ -2400,12 +2400,12 @@ static int test_union_param(MYSQL *mysql)
   my_bind[0].buffer=         (char*) &my_val;
   my_bind[0].buffer_length=  4;
   my_bind[0].length=         &my_length;
-  my_bind[0].is_null=        (char*)&my_null;
+  my_bind[0].is_null=        &my_null;
   my_bind[1].buffer_type=    MYSQL_TYPE_STRING;
   my_bind[1].buffer=         (char*) &my_val;
   my_bind[1].buffer_length=  4;
   my_bind[1].length=         &my_length;
-  my_bind[1].is_null=        (char*)&my_null;
+  my_bind[1].is_null=        &my_null;
 
   rc= mysql_stmt_bind_param(stmt, my_bind);
   check_stmt_rc(rc, stmt);
@@ -3313,7 +3313,7 @@ ENGINE=InnoDB DEFAULT CHARSET=utf8");
   my_bind[0].buffer_type= MYSQL_TYPE_LONG;
   my_bind[0].buffer= (void *)&my_val;
   my_bind[0].length= &my_length;
-  my_bind[0].is_null= (char*)&my_null;
+  my_bind[0].is_null= &my_null;
   my_val= 1;
   rc= mysql_stmt_bind_param(stmt, my_bind);
   check_stmt_rc(rc, stmt);

--- a/unittest/libmariadb/view.c
+++ b/unittest/libmariadb/view.c
@@ -30,7 +30,7 @@ static int test_view(MYSQL *mysql)
   MYSQL_BIND      my_bind[1];
   char            str_data[50];
   ulong           length = 0L;
-  long            is_null = 0L;
+  my_bool         is_null = 0L;
   const char *query=
     "SELECT COUNT(*) FROM v1 WHERE SERVERNAME=?";
 
@@ -84,7 +84,7 @@ static int test_view(MYSQL *mysql)
   my_bind[0].buffer_length= 50;
   my_bind[0].length= &length;
   length= 4;
-  my_bind[0].is_null= (char*)&is_null;
+  my_bind[0].is_null= &is_null;
   rc= mysql_stmt_bind_param(stmt, my_bind);
   check_stmt_rc(rc, stmt);
 
@@ -301,7 +301,7 @@ static int test_view_insert(MYSQL *mysql)
   MYSQL_BIND      my_bind[1];
   int             my_val = 0;
   ulong           my_length = 0L;
-  long            my_null = 0L;
+  my_bool         my_null = 0;
   const char *query=
     "insert into v1 values (?)";
 
@@ -328,7 +328,7 @@ static int test_view_insert(MYSQL *mysql)
   my_bind[0].buffer_type = MYSQL_TYPE_LONG;
   my_bind[0].buffer = (char *)&my_val;
   my_bind[0].length = &my_length;
-  my_bind[0].is_null = (char*)&my_null;
+  my_bind[0].is_null = &my_null;
   rc= mysql_stmt_bind_param(insert_stmt, my_bind);
   check_stmt_rc(rc, select_stmt);
 


### PR DESCRIPTION
Prevents legitimate compile warning on Power and other
architectures that define char to be unsigned (which is allowed by C
standard). In this case the SOCKET_ERROR (-1) is never true.

plugins/pvio/pvio_socket.c:763:42: warning: comparison of constant -1 with expression of type 'my_bool' (aka 'char') is always
      false [-Wtautological-constant-out-of-range-compare]
    if (pvio_socket_blocking(pvio, 1, 0) == SOCKET_ERROR)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~
plugins/pvio/pvio_socket.c:875:46: warning: comparison of constant -1 with expression of type 'my_bool' (aka 'char') is always
      false [-Wtautological-constant-out-of-range-compare]
        if (pvio_socket_blocking(pvio, 0, 0) == SOCKET_ERROR)
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~
plugins/pvio/pvio_socket.c:907:42: warning: comparison of constant -1 with expression of type 'my_bool' (aka 'char') is always
      false [-Wtautological-constant-out-of-range-compare]
    if (pvio_socket_blocking(pvio, 1, 0) == SOCKET_ERROR)

I submit this under the MCA.