### PR TITLE
Fix certificate request error on OpenSSL.

### DIFF
--- a/.travis/gen-ssl.sh
+++ b/.travis/gen-ssl.sh
@@ -17,7 +17,7 @@ print_usage () {
 gen_cert_subject () {
   local fqdn="$1"
   [[ "${fqdn}" != "" ]] || print_error "FQDN cannot be blank"
-  echo "/C=/ST=/O=/localityName=/CN=${fqdn}/organizationalUnitName=/emailAddress=/"
+  echo "/C=XX/ST=X/O=X/localityName=X/CN=${fqdn}/organizationalUnitName=X/emailAddress=X/"
 }
 
 main () {


### PR DESCRIPTION
Fedora 28.

```
$ openssl version
OpenSSL 1.1.0h-fips  27 Mar 2018

$ mkdir tmp
$ sh -x .travis/gen-ssl.sh mariadb.example.com tmp
...
+ openssl req -sha1 -new -x509 -nodes -days 3650 -subj /C=/ST=/O=/localityName=/CN=ca.example.com/organizationalUnitName=/emailAddress=/ -key tmp/ca.key -out tmp/ca.crt
problems making Certificate Request
140361806722880:error:0D07A098:asn1 encoding routines:ASN1_mbstring_ncopy:string too short:crypto/asn1/a_mbstr.c:102:minsize=2
```

After checking the source code, and searching it on google, I found empty field was not allowed. We had to set a value >= minvalue for each field.

https://github.com/openssl/openssl/blob/OpenSSL_1_1_0h/crypto/asn1/a_mbstr.c#L102

I do not know why this was not happened in Travis CI. The OpenSSL version is a little bit old?
