### PR TITLE
MDEV-15655: abstract socket support - fix length(2)

### DIFF
--- a/plugins/pvio/pvio_socket.c
+++ b/plugins/pvio/pvio_socket.c
@@ -772,14 +772,15 @@ my_bool pvio_socket_connect(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo)
     if (cinfo->unix_socket[0] == '@')
     {
       strcpy(UNIXaddr.sun_path + 1, cinfo->unix_socket + 1);
+      port_length+= offsetof(struct sockaddr_un, sun_path);
     }
     else
 #endif
     {
       strcpy(UNIXaddr.sun_path, cinfo->unix_socket);
+      port_length= sizeof(UNIXaddr);
     }
-    if (pvio_socket_connect_sync_or_async(pvio, (struct sockaddr *) &UNIXaddr, 
-                                    sizeof(UNIXaddr.sun_family) + port_length))
+    if (pvio_socket_connect_sync_or_async(pvio, (struct sockaddr *) &UNIXaddr, port_length))
     {
       PVIO_SET_ERROR(cinfo->mysql, CR_CONNECTION_ERROR, SQLSTATE_UNKNOWN, 
                     ER(CR_CONNECTION_ERROR), cinfo->unix_socket, socket_errno);


### PR DESCRIPTION
Thanks to Sergey Vojtovich:

On OS X sockaddr_un is defined as:

struct sockaddr_un
{
  u_char sun_len;
  u_char sun_family;
  char  sun_path[104];
};

There is a comment in man 7 unix (on linux):

On Linux, the above offsetof() expression equates to the same value as sizeof(sa_family_t), but some other implementations include other fields before sun_path, so the offsetof() expression more portably describes the size of the address structure.

As such use the offsetof for Linux and use the previous sizeof(UNIXaddr)
for non-unix platforms as that's what worked before and they don't
support abstract sockets so there's no compatibility problem..