### PR TITLE
Fix: use after free()

### DIFF
--- a/unittest/libmariadb/ps.c
+++ b/unittest/libmariadb/ps.c
@@ -4637,7 +4637,6 @@ static int test_stmt_close(MYSQL *mysql)
   FAIL_IF(mysql_stmt_param_count(stmt2) != 1, "param_count != 1");
 
   rc= mysql_stmt_close(stmt1);
-  check_stmt_rc(rc, stmt1);
 
   /*
     Originally we were going to close all statements automatically in


### PR DESCRIPTION
coverity scan says:

```
Error: USE_AFTER_FREE (CWE-825):
mariadb-connector-c-3.0.4-src/unittest/libmariadb/ps.c:4639: freed_arg: "mysql_stmt_close" frees "stmt1".
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_stmt.c:1338:3: freed_arg: "free" frees parameter "stmt".
mariadb-connector-c-3.0.4-src/unittest/libmariadb/ps.c:4640: pass_freed_arg: Passing freed pointer "stmt1" as an argument to "mysql_stmt_error".
# 4638|   
# 4639|     rc= mysql_stmt_close(stmt1);
# 4640|->   check_stmt_rc(rc, stmt1);
# 4641|   
# 4642|     /*
```

Use of the variable stmt1 after it has been freed can lead to the program undefined behaviour.