### PR TITLE
Remove dead code

### DIFF
--- a/libmariadb/ma_default.c
+++ b/libmariadb/ma_default.c
@@ -231,12 +231,7 @@ static my_bool _mariadb_read_options_from_file(MYSQL *mysql,
       key= ptr;
     for ( ; isspace(end[-1]) ; end--) ;
     *end= 0;
-    if (!value)
-    {
-      if (!key)
-        key= ptr;
-    }
-    else
+    if (value)
     {
       /* Remove pre- and end space */
       char *value_end;


### PR DESCRIPTION
Covscan says:

```
Error: UNUSED_VALUE (CWE-563):
mariadb-connector-c-3.0.4-src/libmariadb/ma_default.c:170: value_overwrite: Overwriting previous write to "key" with value "NULL".
mariadb-connector-c-3.0.4-src/libmariadb/ma_default.c:213: assigned_pointer: Assigning value from "ptr" to "key" here, but that stored value is overwritten before it can be used.
#  211|       {
#  212|         if (!key)
#  213|->         key= ptr;
#  214|       }
#  215|       else

Error: DEADCODE (CWE-561):
mariadb-connector-c-3.0.4-src/libmariadb/ma_default.c:172: addr_non_null: The address of an object "buff" is never null.
mariadb-connector-c-3.0.4-src/libmariadb/ma_default.c:172: assignment: Assigning: "ptr" = "buff".
mariadb-connector-c-3.0.4-src/libmariadb/ma_default.c:207: assignment: Assigning: "key" = "ptr".
mariadb-connector-c-3.0.4-src/libmariadb/ma_default.c:212: notnull: At condition "key", the value of "key" cannot be "NULL".
mariadb-connector-c-3.0.4-src/libmariadb/ma_default.c:212: dead_error_condition: The condition "!key" cannot be true.
mariadb-connector-c-3.0.4-src/libmariadb/ma_default.c:213: dead_error_line: Execution cannot reach this statement: "key = ptr;".
#  211|       {
#  212|         if (!key)
#  213|->         key= ptr;
#  214|       }
#  215|       else
```