### PR TITLE
Remove unused code

### DIFF
--- a/libmariadb/ma_net.c
+++ b/libmariadb/ma_net.c
@@ -549,11 +549,9 @@ ulong ma_net_read(NET *net)
         return packet_error;
       if (_mariadb_uncompress((unsigned char*) net->buff + net->where_b, &packet_length, &complen))
       {
-        len= packet_error;
         net->error=2;			/* caller will close socket */
         net->last_errno=ER_NET_UNCOMPRESS_ERROR;
         break;
-        return packet_error;
       }
       buffer_length+= complen;
     }


### PR DESCRIPTION
Please double check after me.

Covscan says:

```
Error: UNUSED_VALUE (CWE-563):
mariadb-connector-c-3.0.4-src/libmariadb/ma_net.c:564: value_overwrite: Overwriting previous write to "len" with value from "current - start - 4UL".
mariadb-connector-c-3.0.4-src/libmariadb/ma_net.c:552: assigned_value: Assigning value "4294967295UL" to "len" here, but that stored value is overwritten before it can be used.
#  550|         if (_mariadb_uncompress((unsigned char*) net->buff + net->where_b, &packet_length, &complen))
#  551|         {
#  552|->         len= packet_error;
#  553|           net->error=2;                 /* caller will close socket */
#  554|           net->last_errno=ER_NET_UNCOMPRESS_ERROR;
```
The value will be overwritten on line 564

Also the 'return' is a dead piece of code, since it will aways jump out (of the for cycle) by the 'break' command right before it.
