### PR TITLE
Remove unused value

### DIFF
--- a/libmariadb/mariadb_dyncol.c
+++ b/libmariadb/mariadb_dyncol.c
@@ -3886,7 +3886,7 @@ mariadb_dyncol_val_str(DYNAMIC_STRING *str, DYNAMIC_COLUMN_VALUE *val,
             return ER_DYNCOL_RESOURCE;
         }
         if (quote)
-          rc= ma_dynstr_append_mem(str, &quote, 1);
+          ma_dynstr_append_mem(str, &quote, 1);
         rc= ma_dynstr_append_mem(str, from, len);
         if (quote)
           rc= ma_dynstr_append_mem(str, &quote, 1);


### PR DESCRIPTION
The value of 'rc' will be overwriten on the very next line.

Covcan says:
```
Error: UNUSED_VALUE (CWE-563):
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_dyncol.c:3891: value_overwrite: Overwriting previous write to "rc" with value from "ma_dynstr_append_mem(str, from, len)".
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_dyncol.c:3890: returned_value: Assigning value from "ma_dynstr_append_mem(str, &quote, 1UL)" to "rc" here, but that stored value is overwritten before it can be used.
# 3888|           }
# 3889|           if (quote)
# 3890|->           rc= ma_dynstr_append_mem(str, &quote, 1);
# 3891|           rc= ma_dynstr_append_mem(str, from, len);
# 3892|           if (quote)
```