### PR TITLE
Remove deadcode

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -1734,8 +1734,8 @@ my_bool	STDCALL mysql_change_user(MYSQL *mysql, const char *user,
   else
     mysql->charset=mysql_find_charset_name(MARIADB_DEFAULT_CHARSET);
 
-  mysql->user= strdup(user ? user : "");
-  mysql->passwd= strdup(passwd ? passwd : "");
+  mysql->user= strdup(user);
+  mysql->passwd= strdup(passwd);
 
   /* db will be set in run_plugin_auth */
   mysql->db= 0;


### PR DESCRIPTION
Covscan says:
```
Error: DEADCODE (CWE-561):
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:1714: string_non_null: String literal """" is never null.
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:1714: assignment: Assigning: "user" = """".
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:1725: notnull: At condition "user", the value of "user" cannot be "NULL".
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:1725: dead_error_condition: The condition "user" must be true.
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:1725: dead_error_line: Execution cannot reach the expression """" inside this statement: "mysql->user = strdup((user ...".
# 1723|       mysql->charset=ma_default_charset_info;
# 1724|   
# 1725|->   mysql->user= strdup(user ? user : "");
# 1726|     mysql->passwd= strdup(passwd ? passwd : "");
# 1727|   

Error: DEADCODE (CWE-561):
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:1714: string_non_null: String literal """" is never null.
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:1716: assignment: Assigning: "passwd" = """".
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:1726: notnull: At condition "passwd", the value of "passwd" cannot be "NULL".
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:1726: dead_error_condition: The condition "passwd" must be true.
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:1726: dead_error_line: Execution cannot reach the expression """" inside this statement: "mysql->passwd = strdup((pas...".
# 1724|   
# 1725|     mysql->user= strdup(user ? user : "");
# 1726|->   mysql->passwd= strdup(passwd ? passwd : "");
# 1727|   
# 1728|     /* db will be set in run_plugin_auth */
```