### PR TITLE
Remove dead code

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -3145,9 +3145,6 @@ mysql_get_optionv(MYSQL *mysql, enum mysql_option option, void *arg, ...)
       if (!(elements= va_arg(ap, unsigned int *)))
         goto error;
 
-      if (!elements)
-        goto error;
-
       *elements= 0;
 
       if (!mysql->options.extension ||


### PR DESCRIPTION
Covscan says:
```
Error: DEADCODE (CWE-561):
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:3124: cond_notnull: Condition "elements = va_arg (ap, unsigned int *)", taking true branch. Now the value of "elements" is not "NULL".
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:3127: notnull: At condition "elements", the value of "elements" cannot be "NULL".
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:3127: dead_error_condition: The condition "!elements" cannot be true.
mariadb-connector-c-3.0.4-src/libmariadb/mariadb_lib.c:3128: dead_error_line: Execution cannot reach this statement: "goto error;".
# 3126|   
# 3127|         if (!elements)
# 3128|->         goto error;
# 3129|   
# 3130|         *elements= 0;
```