### PR TITLE
Fix double free()

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -1606,7 +1606,8 @@ my_bool STDCALL mariadb_reconnect(MYSQL *mysql)
     return(1);
   }
 
-  mysql_init(&tmp_mysql);
+  if(mysql_init(&tmp_mysql) == 0)
+    return(1);
   tmp_mysql.options=mysql->options;
   if (mysql->extension->conn_hdlr)
   {


### PR DESCRIPTION
covscan says:

```
Error: BAD_FREE (CWE-763):
mariadb-connector-c-3.0.5-src/libmariadb/mariadb_lib.c:1609: address_free: "mysql_init" frees address of "tmp_mysql".
mariadb-connector-c-3.0.5-src/libmariadb/mariadb_lib.c:1014:5: freed_arg: "free" frees parameter "mysql".
mariadb-connector-c-3.0.5-src/libmariadb/mariadb_lib.c:1640: address_free: "mysql_close" frees address of "tmp_mysql".
mariadb-connector-c-3.0.5-src/libmariadb/mariadb_lib.c:1952:7: freed_arg: "free" frees parameter "mysql".
# 1950|       mysql->net.pvio= 0;
# 1951|       if (mysql->free_me)
# 1952|->       free(mysql);
# 1953|     }
# 1954|     return;

```

Please check if that makes some sense.
I'd say, if mysql_init() fails and returns 0; this value should be checked here to avoid double free().