### PR TITLE
Fix NEGATIVE_RETURNS

### DIFF
--- a/plugins/auth/sha256_pw.c
+++ b/plugins/auth/sha256_pw.c
@@ -128,6 +128,8 @@ char *load_pub_key_file(const char *filename, int *pub_key_size)
     goto end;
 
   *pub_key_size= ftell(fp);
+  if(*pub_key_size ==0)
+    goto end;
   rewind(fp);
 
   if (!(buffer= malloc(*pub_key_size + 1)))


### PR DESCRIPTION
covscan says:

```
Error: NEGATIVE_RETURNS (CWE-394):
mariadb-connector-c-3.0.5-src/plugins/auth/sha256_pw.c:130: negative_return_fn: Function "ftell(fp)" returns a negative number.
mariadb-connector-c-3.0.5-src/plugins/auth/sha256_pw.c:130: var_assign: Assigning: signed variable "*pub_key_size" = "ftell".
mariadb-connector-c-3.0.5-src/plugins/auth/sha256_pw.c:136: negative_returns: "*pub_key_size" is passed to a parameter that cannot be negative. [Note: The source code implementation of the function has been ove$
#  134|       goto end;
#  135|   
#  136|->   if (!fread(buffer, *pub_key_size, 1, fp))
#  137|       goto end;
#  138|   

```