### PR TITLE
CONC-329: change pvio_*_blocking to return int to accomidate SOCKET_ERROR(-1)

### DIFF
--- a/include/ma_pvio.h
+++ b/include/ma_pvio.h
@@ -98,7 +98,7 @@ struct st_ma_pvio_methods
   ssize_t (*write)(MARIADB_PVIO *pvio, const uchar *buffer, size_t length);
   ssize_t (*async_write)(MARIADB_PVIO *pvio, const uchar *buffer, size_t length);
   int (*wait_io_or_timeout)(MARIADB_PVIO *pvio, my_bool is_read, int timeout);
-  my_bool (*blocking)(MARIADB_PVIO *pvio, my_bool value, my_bool *old_value);
+  int (*blocking)(MARIADB_PVIO *pvio, my_bool value, my_bool *old_value);
   my_bool (*connect)(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo);
   my_bool (*close)(MARIADB_PVIO *pvio);
   int (*fast_send)(MARIADB_PVIO *pvio);

--- a/include/mariadb_dyncol.h
+++ b/include/mariadb_dyncol.h
@@ -225,7 +225,7 @@ void mariadb_dyncol_free(DYNAMIC_COLUMN *str);
 /* conversion of values to 3 base types */
 enum enum_dyncol_func_result
 mariadb_dyncol_val_str(DYNAMIC_STRING *str, DYNAMIC_COLUMN_VALUE *val,
-                       MARIADB_CHARSET_INFO *cs, my_bool quote);
+                       MARIADB_CHARSET_INFO *cs, char quote);
 enum enum_dyncol_func_result
 mariadb_dyncol_val_long(longlong *ll, DYNAMIC_COLUMN_VALUE *val);
 enum enum_dyncol_func_result

--- a/libmariadb/ma_pvio.c
+++ b/libmariadb/ma_pvio.c
@@ -490,7 +490,7 @@ my_bool ma_pvio_connect(MARIADB_PVIO *pvio,  MA_PVIO_CINFO *cinfo)
 my_bool ma_pvio_blocking(MARIADB_PVIO *pvio, my_bool block, my_bool *previous_mode)
 {
   if (pvio && pvio->methods->blocking)
-    return pvio->methods->blocking(pvio, block, previous_mode);
+    return pvio->methods->blocking(pvio, block, previous_mode) != 0;
   return 1;
 }
 /* }}} */

--- a/libmariadb/ma_tls.c
+++ b/libmariadb/ma_tls.c
@@ -130,7 +130,7 @@ const char *ma_pvio_tls_get_protocol_version(MARIADB_TLS *ctls)
   return tls_protocol_version[version];
 }
 
-static char ma_hex2int(char c)
+static signed char ma_hex2int(char c)
 {
   if (c >= '0' && c <= '9')
     return c - '0';
@@ -161,7 +161,7 @@ static my_bool ma_pvio_tls_compare_fp(const char *cert_fp,
 
   for(c= (char *)cert_fp; c < cert_fp + cert_fp_len; c++)
   {
-    char d1, d2;
+    signed char d1, d2;
     if (*p == ':')
       p++;
     if (p - fp > (int)fp_len -1)

--- a/plugins/pvio/pvio_npipe.c
+++ b/plugins/pvio/pvio_npipe.c
@@ -38,7 +38,7 @@ ssize_t pvio_npipe_async_read(MARIADB_PVIO *pvio, uchar *buffer, size_t length);
 ssize_t pvio_npipe_write(MARIADB_PVIO *pvio, const uchar *buffer, size_t length);
 ssize_t pvio_npipe_async_write(MARIADB_PVIO *pvio, const uchar *buffer, size_t length);
 int pvio_npipe_wait_io_or_timeout(MARIADB_PVIO *pvio, my_bool is_read, int timeout);
-my_bool pvio_npipe_blocking(MARIADB_PVIO *pvio, my_bool value, my_bool *old_value);
+int pvio_npipe_blocking(MARIADB_PVIO *pvio, my_bool value, my_bool *old_value);
 my_bool pvio_npipe_connect(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo);
 my_bool pvio_npipe_close(MARIADB_PVIO *pvio);
 int pvio_npipe_fast_send(MARIADB_PVIO *pvio);
@@ -187,7 +187,7 @@ int pvio_npipe_wait_io_or_timeout(MARIADB_PVIO *pvio, my_bool is_read, int timeo
   return -1;
 }
 
-my_bool pvio_npipe_blocking(MARIADB_PVIO *pvio, my_bool block, my_bool *previous_mode)
+int pvio_npipe_blocking(MARIADB_PVIO *pvio, my_bool block, my_bool *previous_mode)
 {
   /* not supported */
   DWORD flags= 0;

--- a/plugins/pvio/pvio_shmem.c
+++ b/plugins/pvio/pvio_shmem.c
@@ -36,7 +36,7 @@ int pvio_shm_get_timeout(MARIADB_PVIO *pvio, enum enum_pvio_timeout type);
 ssize_t pvio_shm_read(MARIADB_PVIO *pvio, uchar *buffer, size_t length);
 ssize_t pvio_shm_write(MARIADB_PVIO *pvio, const uchar *buffer, size_t length);
 int pvio_shm_wait_io_or_timeout(MARIADB_PVIO *pvio, my_bool is_read, int timeout);
-my_bool pvio_shm_blocking(MARIADB_PVIO *pvio, my_bool value, my_bool *old_value);
+int pvio_shm_blocking(MARIADB_PVIO *pvio, my_bool value, my_bool *old_value);
 my_bool pvio_shm_connect(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo);
 my_bool pvio_shm_close(MARIADB_PVIO *pvio);
 int pvio_shm_shutdown(MARIADB_PVIO *pvio);
@@ -218,7 +218,7 @@ int pvio_shm_wait_io_or_timeout(MARIADB_PVIO *pvio, my_bool is_read, int timeout
   return 0;
 }
 
-my_bool pvio_shm_blocking(MARIADB_PVIO *pvio, my_bool block, my_bool *previous_mode)
+int pvio_shm_blocking(MARIADB_PVIO *pvio, my_bool block, my_bool *previous_mode)
 {
   /* not supported */
   return 0;

--- a/plugins/pvio/pvio_socket.c
+++ b/plugins/pvio/pvio_socket.c
@@ -92,7 +92,7 @@ ssize_t pvio_socket_async_read(MARIADB_PVIO *pvio, uchar *buffer, size_t length)
 ssize_t pvio_socket_async_write(MARIADB_PVIO *pvio, const uchar *buffer, size_t length);
 ssize_t pvio_socket_write(MARIADB_PVIO *pvio, const uchar *buffer, size_t length);
 int pvio_socket_wait_io_or_timeout(MARIADB_PVIO *pvio, my_bool is_read, int timeout);
-my_bool pvio_socket_blocking(MARIADB_PVIO *pvio, my_bool value, my_bool *old_value);
+int pvio_socket_blocking(MARIADB_PVIO *pvio, my_bool value, my_bool *old_value);
 my_bool pvio_socket_connect(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo);
 my_bool pvio_socket_close(MARIADB_PVIO *pvio);
 int pvio_socket_fast_send(MARIADB_PVIO *pvio);
@@ -565,7 +565,7 @@ int pvio_socket_wait_io_or_timeout(MARIADB_PVIO *pvio, my_bool is_read, int time
   return rc;
 }
 
-my_bool pvio_socket_blocking(MARIADB_PVIO *pvio, my_bool block, my_bool *previous_mode)
+int pvio_socket_blocking(MARIADB_PVIO *pvio, my_bool block, my_bool *previous_mode)
 {
   my_bool is_blocking;
   struct st_pvio_socket *csock;

--- a/unittest/libmariadb/ps.c
+++ b/unittest/libmariadb/ps.c
@@ -2209,7 +2209,7 @@ static int test_bind_negative(MYSQL *mysql)
   my_bind[0].buffer_type= MYSQL_TYPE_LONG;
   my_bind[0].buffer= (void *)&my_val;
   my_bind[0].length= &my_length;
-  my_bind[0].is_null= (char*)&my_null;
+  my_bind[0].is_null= &my_null;
 
   rc= mysql_stmt_bind_param(stmt, my_bind);
   check_stmt_rc(rc, stmt);
@@ -2400,12 +2400,12 @@ static int test_union_param(MYSQL *mysql)
   my_bind[0].buffer=         (char*) &my_val;
   my_bind[0].buffer_length=  4;
   my_bind[0].length=         &my_length;
-  my_bind[0].is_null=        (char*)&my_null;
+  my_bind[0].is_null=        &my_null;
   my_bind[1].buffer_type=    MYSQL_TYPE_STRING;
   my_bind[1].buffer=         (char*) &my_val;
   my_bind[1].buffer_length=  4;
   my_bind[1].length=         &my_length;
-  my_bind[1].is_null=        (char*)&my_null;
+  my_bind[1].is_null=        &my_null;
 
   rc= mysql_stmt_bind_param(stmt, my_bind);
   check_stmt_rc(rc, stmt);
@@ -3313,7 +3313,7 @@ ENGINE=InnoDB DEFAULT CHARSET=utf8");
   my_bind[0].buffer_type= MYSQL_TYPE_LONG;
   my_bind[0].buffer= (void *)&my_val;
   my_bind[0].length= &my_length;
-  my_bind[0].is_null= (char*)&my_null;
+  my_bind[0].is_null= &my_null;
   my_val= 1;
   rc= mysql_stmt_bind_param(stmt, my_bind);
   check_stmt_rc(rc, stmt);

--- a/unittest/libmariadb/view.c
+++ b/unittest/libmariadb/view.c
@@ -30,7 +30,7 @@ static int test_view(MYSQL *mysql)
   MYSQL_BIND      my_bind[1];
   char            str_data[50];
   ulong           length = 0L;
-  long            is_null = 0L;
+  my_bool         is_null = 0;
   const char *query=
     "SELECT COUNT(*) FROM v1 WHERE SERVERNAME=?";
 
@@ -84,7 +84,7 @@ static int test_view(MYSQL *mysql)
   my_bind[0].buffer_length= 50;
   my_bind[0].length= &length;
   length= 4;
-  my_bind[0].is_null= (char*)&is_null;
+  my_bind[0].is_null= &is_null;
   rc= mysql_stmt_bind_param(stmt, my_bind);
   check_stmt_rc(rc, stmt);
 
@@ -301,7 +301,7 @@ static int test_view_insert(MYSQL *mysql)
   MYSQL_BIND      my_bind[1];
   int             my_val = 0;
   ulong           my_length = 0L;
-  long            my_null = 0L;
+  my_bool         my_null = 0;
   const char *query=
     "insert into v1 values (?)";
 
@@ -328,7 +328,7 @@ static int test_view_insert(MYSQL *mysql)
   my_bind[0].buffer_type = MYSQL_TYPE_LONG;
   my_bind[0].buffer = (char *)&my_val;
   my_bind[0].length = &my_length;
-  my_bind[0].is_null = (char*)&my_null;
+  my_bind[0].is_null = &my_null;
   rc= mysql_stmt_bind_param(insert_stmt, my_bind);
   check_stmt_rc(rc, select_stmt);
 


### PR DESCRIPTION
POWER and other architectures that define char(as my_bool) to be unsigned (as the C
standard leaves this undefined). This resulted in error branches being
unreachabe as indicated by the below compile warnings.

plugins/pvio/pvio_socket.c:763:42: warning: comparison of constant -1 with expression of type 'my_bool' (aka 'char') is always
      false [-Wtautological-constant-out-of-range-compare]
    if (pvio_socket_blocking(pvio, 1, 0) == SOCKET_ERROR)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~
plugins/pvio/pvio_socket.c:875:46: warning: comparison of constant -1 with expression of type 'my_bool' (aka 'char') is always
      false [-Wtautological-constant-out-of-range-compare]
        if (pvio_socket_blocking(pvio, 0, 0) == SOCKET_ERROR)
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~
plugins/pvio/pvio_socket.c:907:42: warning: comparison of constant -1 with expression of type 'my_bool' (aka 'char') is always
      false [-Wtautological-constant-out-of-range-compare]
    if (pvio_socket_blocking(pvio, 1, 0) == SOCKET_ERROR)

ma_hext2int: signed char - prevent compiler errors when char is unsigned.

libmariadb/ma_tls.c:169:31: warning: comparison of constant -1 with expression of type 'char' is always false
      [-Wtautological-constant-out-of-range-compare]
    if ((d1 = ma_hex2int(*p)) == - 1 ||
        ~~~~~~~~~~~~~~~~~~~~~ ^  ~~~
libmariadb/ma_tls.c:170:35: warning: comparison of constant -1 with expression of type 'char' is always false
      [-Wtautological-constant-out-of-range-compare]
        (d2 = ma_hex2int(*(p+1))) == -1 ||
        ~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~

To fix this all the pvio_*_blocking functions have been changed to use
int as a return value.

Other my_bool/char differences fixed:

mariadb_dyncol_val_str: fix prototype to use char - like implemented function.

unittest: bind.is_null is my_bool* so we use a my_bool.

I submit this under the MCA.