### PR TITLE
CMake: link to external zlib on Windows if "WITH_EXTERNAL_ZLIB" is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,7 +344,7 @@ CONFIGURE_FILE(${CC_SOURCE_DIR}/include/mariadb_version.h.in
 INCLUDE_DIRECTORIES(${CC_BINARY_DIR}/include)
 
 IF(WIN32)
-  SET(SYSTEM_LIBS ws2_32 advapi32 kernel32 shlwapi crypt32)
+  SET(SYSTEM_LIBS ws2_32 advapi32 kernel32 shlwapi crypt32 ${LIBZ})
 ELSE()
   SET(SYSTEM_LIBS ${SYSTEM_LIBS} ${LIBPTHREAD} ${LIBDL} ${LIBM})
   IF(ICONV_EXTERNAL)


### PR DESCRIPTION
This fixes the `undefined reference to 'compress'` and `undefined reference to 'uncompress'` errors.