### PR TITLE
Fix type of pcbStructInfo param of CryptDecodeObjectEx

### DIFF
--- a/plugins/auth/caching_sha2_pw.c
+++ b/plugins/auth/caching_sha2_pw.c
@@ -256,7 +256,7 @@ static int auth_caching_sha2_client(MYSQL_PLUGIN_VIO *vio, MYSQL *mysql)
   DWORD der_buffer_len= 0;
   CERT_PUBLIC_KEY_INFO *publicKeyInfo= NULL;
   DWORD ParamSize= sizeof(DWORD);
-  int publicKeyInfoLen;
+  DWORD publicKeyInfoLen;
 #endif
 
   /* read error */


### PR DESCRIPTION
The `pcbStructInfo` parameter of `CryptDecodeObjectEx` is `DWORD*`, not `int*`