### PR TITLE
Consistent type result of ternary operator in auth_caching_sha2_client

### DIFF
--- a/plugins/auth/caching_sha2_pw.c
+++ b/plugins/auth/caching_sha2_pw.c
@@ -348,7 +348,7 @@ static int auth_caching_sha2_client(MYSQL_PLUGIN_VIO *vio, MYSQL *mysql)
     der_buffer_len= packet_length;
     /* Load pem and convert it to binary object. New length will be returned
        in der_buffer_len */
-    if (!(der_buffer= ma_load_pem(filebuffer ? filebuffer : packet, &der_buffer_len)))
+    if (!(der_buffer= ma_load_pem(filebuffer ? filebuffer : (char *)packet, &der_buffer_len)))
       goto error;
 
     /* Create context and load public key */


### PR DESCRIPTION
We have that `filebuffer` is a `char*` and `packet` is an `unsigned char *`.
Let's make the ternary operator always return the same type (`char*`, the one expected by `ma_load_pem`).