### PR TITLE
Use lower case SecExt.h

### DIFF
--- a/plugins/auth/sspi_client.c
+++ b/plugins/auth/sspi_client.c
@@ -29,7 +29,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define SECURITY_WIN32
 #include <windows.h>
 #include <sspi.h>
-#include <SecExt.h>
+#include <secext.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/plugins/auth/sspi_common.h
+++ b/plugins/auth/sspi_common.h
@@ -29,7 +29,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define SECURITY_WIN32
 #include <windows.h>
 #include <sspi.h>
-#include <SecExt.h>
+#include <secext.h>
 #include <stdarg.h>
 #include <stdio.h>
 


### PR DESCRIPTION
This is required when cross-compiling for Windows under case-sensitive systems