### PR TITLE
openssl: Fix version check for ERR_remove_state

### DIFF
--- a/libmariadb/secure/openssl.c
+++ b/libmariadb/secure/openssl.c
@@ -412,8 +412,10 @@ void ma_tls_end()
     if (mariadb_deinitialize_ssl)
     {
 #ifndef HAVE_OPENSSL_1_1_API
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
       ERR_remove_state(0);
+#else
+      ERR_remove_thread_state(NULL);
 #endif
       EVP_cleanup();
       CRYPTO_cleanup_all_ex_data();


### PR DESCRIPTION
ERR_remove_state was deprecated in 1.0.0, not later.

Fixes compilation with OpenSSL 1.0.2 with deprecated APIs disabled.