### PR TITLE
Fix table map event processing

### DIFF
--- a/include/mariadb_rpl.h
+++ b/include/mariadb_rpl.h
@@ -201,7 +201,7 @@ struct st_mariadb_rpl_table_map_event {
   MARIADB_STRING database;
   MARIADB_STRING table;
   unsigned int column_count;
-  char *column_types;
+  MARIADB_STRING column_types;
   MARIADB_STRING metadata;
   char *null_indicator;
 };

--- a/libmariadb/mariadb_rpl.c
+++ b/libmariadb/mariadb_rpl.c
@@ -238,10 +238,12 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
       ev++;
       if (rpl_alloc_string(rpl_event, &rpl_event->event.table_map.table, ev, len))
         goto mem_error;
-      ev+= len;
+      ev+= len + 1;
       rpl_event->event.table_map.column_count= mysql_net_field_length(&ev);
-      rpl_event->event.table_map.column_types= (char *)ev;
-      ev+= rpl_event->event.table_map.column_count;
+      len= rpl_event->event.table_map.column_count;
+      if (rpl_alloc_string(rpl_event, &rpl_event->event.table_map.column_types, ev, len))
+        goto mem_error;
+      ev+= len;
       len= mysql_net_field_length(&ev);
       if (rpl_alloc_string(rpl_event, &rpl_event->event.table_map.metadata, ev, len))
         goto mem_error;


### PR DESCRIPTION
The table name is also null-terminated so the length plus one byte needs
to be skipped.

If the table map event is not used immediately after the event is read,
the column types would point to possibly freed memory. To avoid this,
memory should be allocated for it.