### PR TITLE
Support static linking auth plugins

### DIFF
--- a/plugins/auth/caching_sha2_pw.c
+++ b/plugins/auth/caching_sha2_pw.c
@@ -194,7 +194,7 @@ end:
 }
 #endif
 
-char *load_pub_key_file(const char *filename, int *pub_key_size)
+static char *load_pub_key_file(const char *filename, int *pub_key_size)
 {
   FILE *fp= NULL;
   char *buffer= NULL;

--- a/plugins/auth/sha256_pw.c
+++ b/plugins/auth/sha256_pw.c
@@ -112,7 +112,7 @@ end:
 }
 #endif
 
-char *load_pub_key_file(const char *filename, int *pub_key_size)
+static char *load_pub_key_file(const char *filename, int *pub_key_size)
 {
   FILE *fp= NULL;
   char *buffer= NULL;


### PR DESCRIPTION
It was failed when both of caching_sha2_password and sha256_password
are linked statically.