### PR TITLE
Fix my.cnf "host" option

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -1206,7 +1206,9 @@ MYSQL *mthd_my_real_connect(MYSQL *mysql, const char *host, const char *user,
   if (!host || !host[0])
     host = mysql->options.host;
 
-  ma_set_connect_attrs(mysql, host);
+  if (ma_set_connect_attrs(mysql, host))
+    /* client error should be set already */
+    return(NULL);
 
   if (net->pvio)  /* check if we are already connected */
   {
@@ -3018,7 +3020,7 @@ mysql_optionsv(MYSQL *mysql,enum mysql_option option, ...)
   default:
     va_end(ap);
     SET_CLIENT_ERROR(mysql, CR_NOT_IMPLEMENTED, SQLSTATE_UNKNOWN, 0);
-    return(-1);
+    return(1);
   }
   va_end(ap);
   return(0);

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -3017,6 +3017,7 @@ mysql_optionsv(MYSQL *mysql,enum mysql_option option, ...)
     break;
   default:
     va_end(ap);
+    SET_CLIENT_ERROR(mysql, CR_NOT_IMPLEMENTED, SQLSTATE_UNKNOWN, 0);
     return(-1);
   }
   va_end(ap);

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -1228,6 +1228,15 @@ MYSQL *mthd_my_real_connect(MYSQL *mysql, const char *host, const char *user,
     mysql->options.my_cnf_file=mysql->options.my_cnf_group=0;
   }
 
+  /* We already checked host earlier, but if it is still unset, use the value
+     from my_cnf_file, and then set _server_host if possible. */
+  if (!host || !host[0])
+    host = mysql->options.host;
+  if (host && *host) {
+    if (mysql_optionsv(mysql, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", host))
+      return(NULL);
+  }
+
 #ifndef WIN32
   if (mysql->options.protocol > MYSQL_PROTOCOL_SOCKET)
   {


### PR DESCRIPTION
It has been possible in the past to have a my.cnf file containing:

```
[example]
host = db.example.com
user = example_user
password = example_password
```
Clients using the mysql or mariadb library (eg perl's DBD::mysql in my case) could be directed to use the `example` group in order to fetch all the necessary settings.

Recently, this feature stopped working--the client would attempt to connect to the local socket rather than the specified host.

This PR fixes that and add some well-intended and hopefully-correct error checking. If the error checking is not desired, than I can submit a simple version without it.

Thanks,
Corey