### PR TITLE
 Reserve the correct amount of space for date/time types 

### DIFF
--- a/libmariadb/my_stmt.c
+++ b/libmariadb/my_stmt.c
@@ -662,8 +662,16 @@ unsigned char* mysql_stmt_execute_generate_request(MYSQL_STMT *stmt, size_t *req
           case MYSQL_TYPE_ENUM:
           case MYSQL_TYPE_BIT:
           case MYSQL_TYPE_SET:
-            data_size+= 5; /* max 8 bytes for size */
+            data_size+= 9; /* max 8 bytes for size */
             data_size+= (size_t)*stmt->params[i].length;
+            break;
+          case MYSQL_TYPE_DATE:
+          case MYSQL_TYPE_TIMESTAMP:
+          case MYSQL_TYPE_DATETIME:
+            data_size += MAX_DATETIME_STR_LEN;
+            break;
+          case MYSQL_TYPE_TIME:
+            data_size += MAX_TIME_STR_LEN;
             break;
           default:
             data_size+= mysql_ps_fetch_functions[stmt->params[i].buffer_type].pack_len;

--- a/libmariadb/my_stmt.c
+++ b/libmariadb/my_stmt.c
@@ -508,7 +508,7 @@ int store_param(MYSQL_STMT *stmt, int column, unsigned char **p)
     if (t->second_part)
     {
       int4store(t_buffer + 8, t->second_part);
-      len= 12;
+      len= 11;
     }
     else if (t->hour || t->minute || t->second)
       len= 7;


### PR DESCRIPTION
This fixes sporadic crashes due to heap corruption