### PR TITLE
Reserve the correct amount of space for date/time types

### DIFF
--- a/libmariadb/mariadb_stmt.c
+++ b/libmariadb/mariadb_stmt.c
@@ -790,8 +790,16 @@ unsigned char* mysql_stmt_execute_generate_simple_request(MYSQL_STMT *stmt, size
         case MYSQL_TYPE_ENUM:
         case MYSQL_TYPE_BIT:
         case MYSQL_TYPE_SET:
-          size+= 5; /* max 8 bytes for size */
+          size+= 9; /* max 9 bytes for size */
           size+= (size_t)ma_get_length(stmt, i, 0);
+          break;
+        case MYSQL_TYPE_DATE:
+        case MYSQL_TYPE_TIMESTAMP:
+        case MYSQL_TYPE_DATETIME:
+          size += MAX_DATETIME_STR_LEN;
+          break;
+        case MYSQL_TYPE_TIME:
+          size += MAX_TIME_STR_LEN;
           break;
         default:
           size+= mysql_ps_fetch_functions[stmt->params[i].buffer_type].pack_len;
@@ -987,7 +995,7 @@ unsigned char* mysql_stmt_execute_generate_bulk_request(MYSQL_STMT *stmt, size_t
           case MYSQL_TYPE_ENUM:
           case MYSQL_TYPE_BIT:
           case MYSQL_TYPE_SET:
-            size+= 5; /* max 8 bytes for size */
+            size+= 9; /* max 9 bytes for size */
             if (!stmt->param_callback)
             {
               if (indicator == STMT_INDICATOR_NTS ||
@@ -1003,6 +1011,14 @@ unsigned char* mysql_stmt_execute_generate_bulk_request(MYSQL_STMT *stmt, size_t
             else {
               size+= stmt->params[i].buffer_length;
             }
+            break;
+          case MYSQL_TYPE_DATE:
+          case MYSQL_TYPE_TIMESTAMP:
+          case MYSQL_TYPE_DATETIME:
+            size += MAX_DATETIME_STR_LEN;
+            break;
+          case MYSQL_TYPE_TIME:
+            size += MAX_TIME_STR_LEN;
             break;
           default:
             size+= mysql_ps_fetch_functions[stmt->params[i].buffer_type].pack_len;


### PR DESCRIPTION
This fixes a crash, when more then 1024 Bytes are required, but the incorrect amount of memory was reserved, leading to a heap corruption.