### PR TITLE
MDEV-16383 Add mariadb_config --libmysqld-libs option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,12 @@ ELSEIF()
   SET(HAVE_THREADS ${CMAKE_USE_PTHREADS})
 ENDIF()
 
+# only let mariadb-config return the embedded server build flags
+# if the library was actually built
+IF(IS_SUBPROJECT AND WITH_EMBEDDED_SERVER)
+  ADD_DEFINITIONS(-DHAVE_EMBEDDED)
+ENDIF()
+
 # check for various include files
 INCLUDE(${CC_SOURCE_DIR}/cmake/CheckIncludeFiles.cmake)
 # check for various functions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ ENDIF()
 # only let mariadb-config return the embedded server build flags
 # if the library was actually built
 IF(IS_SUBPROJECT AND WITH_EMBEDDED_SERVER)
+  SET(EMBEDDED_STATUS "yes")
   ADD_DEFINITIONS(-DHAVE_EMBEDDED)
 ENDIF()
 
@@ -497,4 +498,5 @@ MESSAGE1(STATUS "MariaDB Connector/c configuration:
 -- Libraries will be installed in ${INSTALL_LIBDIR}
 -- Binaries will be installed in ${INSTALL_BINDIR}
 -- Documentation included from ${CLIENT_DOCS}
--- Required: ${CMAKE_REQUIRED_LIBRARIES}")
+-- Required: ${CMAKE_REQUIRED_LIBRARIES}
+-- Embedded library config: ${EMBEDDED_STATUS}")

--- a/mariadb_config/mariadb_config.c.in
+++ b/mariadb_config/mariadb_config.c.in
@@ -35,8 +35,8 @@ static struct option long_options[]=
   {"tlsinfo", no_argument, 0, 'k'},
 #ifdef HAVE_EMBEDDED
   {"libmysqld-libs", no_argument, 0, 'm' },
-  {"embedded-libs", no_argument, 0, 'm' },
-  {"embedded", no_argument, 0, 'm' },
+  {"embedded-libs", no_argument, 0, 'n' },
+  {"embedded", no_argument, 0, 'o' },
 #endif
   {NULL, 0, 0, 0}
 };

--- a/mariadb_config/mariadb_config.c.in
+++ b/mariadb_config/mariadb_config.c.in
@@ -15,7 +15,9 @@ static char *mariadb_progname;
 #define SOCKET  "@MARIADB_UNIX_ADDR@"
 #define PORT "@MARIADB_PORT@"
 #define TLS_LIBRARY_VERSION "@TLS_LIBRARY_VERSION@"
+#ifdef HAVE_EMBEDDED
 #define EMBED_LIBS "-L@CMAKE_INSTALL_PREFIX@/@INSTALL_LIBDIR@/ -lmariadbd @extra_dynamic_LDFLAGS@"
+#endif
 
 static struct option long_options[]=
 {
@@ -31,9 +33,11 @@ static struct option long_options[]=
   {"port", no_argument, 0, 'i'},
   {"plugindir", no_argument, 0, 'j'},
   {"tlsinfo", no_argument, 0, 'k'},
+#ifdef HAVE_EMBEDDED
   {"libmysqld-libs", no_argument, 0, 'm' },
   {"embedded-libs", no_argument, 0, 'm' },
   {"embedded", no_argument, 0, 'm' },
+#endif
   {NULL, 0, 0, 0}
 };
 
@@ -51,9 +55,11 @@ static const char *values[]=
   PORT,
   PLUGIN_DIR,
   TLS_LIBRARY_VERSION,
+#ifdef HAVE_EMBEDDED
   EMBED_LIBS,
   EMBED_LIBS,
   EMBED_LIBS,
+#endif
 };
 
 void usage(void)
@@ -122,9 +128,11 @@ int main(int argc, char **argv)
     case 'l':
       puts(LIBS_SYS);
       break;
+#ifdef HAVE_EMBEDDED
     case 'm':
       puts(EMBED_LIBS);
       break;
+#endif
     default:
       exit((c != -1));
     }

--- a/mariadb_config/mariadb_config.c.in
+++ b/mariadb_config/mariadb_config.c.in
@@ -35,8 +35,8 @@ static struct option long_options[]=
   {"tlsinfo", no_argument, 0, 'k'},
 #ifdef HAVE_EMBEDDED
   {"libmysqld-libs", no_argument, 0, 'm' },
-  {"embedded-libs", no_argument, 0, 'n' },
-  {"embedded", no_argument, 0, 'o' },
+  {"embedded-libs", no_argument, 0, 'm' },
+  {"embedded", no_argument, 0, 'm' },
 #endif
   {NULL, 0, 0, 0}
 };

--- a/mariadb_config/mariadb_config.c.in
+++ b/mariadb_config/mariadb_config.c.in
@@ -15,6 +15,7 @@ static char *mariadb_progname;
 #define SOCKET  "@MARIADB_UNIX_ADDR@"
 #define PORT "@MARIADB_PORT@"
 #define TLS_LIBRARY_VERSION "@TLS_LIBRARY_VERSION@"
+#define EMBED_LIBS "-L@CMAKE_INSTALL_PREFIX@/@INSTALL_LIBDIR@/ -lmariadbd @extra_dynamic_LDFLAGS@"
 
 static struct option long_options[]=
 {
@@ -30,6 +31,9 @@ static struct option long_options[]=
   {"port", no_argument, 0, 'i'},
   {"plugindir", no_argument, 0, 'j'},
   {"tlsinfo", no_argument, 0, 'k'},
+  {"libmysqld-libs", no_argument, 0, 'm' },
+  {"embedded-libs", no_argument, 0, 'm' },
+  {"embedded", no_argument, 0, 'm' },
   {NULL, 0, 0, 0}
 };
 
@@ -46,7 +50,10 @@ static const char *values[]=
   SOCKET,
   PORT,
   PLUGIN_DIR,
-  TLS_LIBRARY_VERSION
+  TLS_LIBRARY_VERSION,
+  EMBED_LIBS,
+  EMBED_LIBS,
+  EMBED_LIBS,
 };
 
 void usage(void)
@@ -114,6 +121,9 @@ int main(int argc, char **argv)
       break;
     case 'l':
       puts(LIBS_SYS);
+      break;
+    case 'm':
+      puts(EMBED_LIBS);
       break;
     default:
       exit((c != -1));


### PR DESCRIPTION
This patch adds the `--libmysqld-libs`, `--embedded-libs` and `--embedded` options to `mariadb_config`.
These return flags for linking against the embdedded mysql/mariadb database library, `libmysqld`/`libmariadbd`.

Fixes: [[MDEV-16383]](https://jira.mariadb.org/browse/MDEV-16383)

We currently have a package in Debian that fails to build because it depends on this option: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=927991
It looks like the option was supported by `mysql_config.sh` previously, but was left out when the shell script was replaced by `mariadb_config.c`.

I added the other two options because they were supported by the shell script, but no `--libmariadbd-libs` option. Please advise if I should add it as well.