### PR TITLE
Fix supporting in external curl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ ADD_OPTION(WITH_SSL "Enables use of TLS/SSL library" ON)
 ###############
 
 INCLUDE(${CC_SOURCE_DIR}/cmake/misc.cmake)
+INCLUDE(FindCURL)
 
 IF(WITH_SIGNCODE)
   IF(WIN32 AND NOT SIGN_OPTIONS)


### PR DESCRIPTION
This line must be in this script for handling the "-DCURL_INCLUDE_DIR=" parameter.
If not the function for searching for curl won't be activated and won't be updated in the makefile.