### PR TITLE
Big endian issue in libmariadb

### DIFF
--- a/libmariadb/ma_dtoa.c
+++ b/libmariadb/ma_dtoa.c
@@ -512,8 +512,8 @@ typedef uint64 ULLong;
 
 typedef union { double d; ULong L[2]; } U;
 
-#if defined(WORDS_BIGENDIAN) || (defined(__FLOAT_WORD_ORDER) &&        \
-                                 (__FLOAT_WORD_ORDER == __BIG_ENDIAN))
+#if defined(HAVE_BIGENDIAN) || defined(WORDS_BIGENDIAN) || \
+   (defined(__FLOAT_WORD_ORDER) && (__FLOAT_WORD_ORDER == __BIG_ENDIAN))
 #define word0(x) (x)->L[0]
 #define word1(x) (x)->L[1]
 #else


### PR DESCRIPTION
Related to [MDEV-19511](https://jira.mariadb.org/browse/MDEV-19511).

On Big-Endian system, test **main.mysql_client_test** fails (after timeout).
This is due to little endian code being used though HAVE_BIGENDIAN  is correctly set (by CMake).
See the [message](https://lists.launchpad.net/maria-developers/msg11819.html) in the mailing list for further information.