### PR TITLE
Revert "MDEV-16383 Add mariadb_config --libmysqld-libs option"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,13 +253,6 @@ ELSEIF()
   SET(HAVE_THREADS ${CMAKE_USE_PTHREADS})
 ENDIF()
 
-# only let mariadb-config return the embedded server build flags
-# if the library was actually built
-IF(IS_SUBPROJECT AND WITH_EMBEDDED_SERVER)
-  SET(EMBEDDED_STATUS "yes")
-  ADD_DEFINITIONS(-DHAVE_EMBEDDED)
-ENDIF()
-
 # check for various include files
 INCLUDE(${CC_SOURCE_DIR}/cmake/CheckIncludeFiles.cmake)
 # check for various functions
@@ -498,5 +491,4 @@ MESSAGE1(STATUS "MariaDB Connector/c configuration:
 -- Libraries will be installed in ${INSTALL_LIBDIR}
 -- Binaries will be installed in ${INSTALL_BINDIR}
 -- Documentation included from ${CLIENT_DOCS}
--- Required: ${CMAKE_REQUIRED_LIBRARIES}
--- Embedded library config: ${EMBEDDED_STATUS}")
+-- Required: ${CMAKE_REQUIRED_LIBRARIES}")

--- a/mariadb_config/mariadb_config.c.in
+++ b/mariadb_config/mariadb_config.c.in
@@ -15,9 +15,6 @@ static char *mariadb_progname;
 #define SOCKET  "@MARIADB_UNIX_ADDR@"
 #define PORT "@MARIADB_PORT@"
 #define TLS_LIBRARY_VERSION "@TLS_LIBRARY_VERSION@"
-#ifdef HAVE_EMBEDDED
-#define EMBED_LIBS "-L@CMAKE_INSTALL_PREFIX@/@INSTALL_LIBDIR@/ -lmariadbd @extra_dynamic_LDFLAGS@"
-#endif
 
 static struct option long_options[]=
 {
@@ -33,11 +30,6 @@ static struct option long_options[]=
   {"port", no_argument, 0, 'i'},
   {"plugindir", no_argument, 0, 'j'},
   {"tlsinfo", no_argument, 0, 'k'},
-#ifdef HAVE_EMBEDDED
-  {"libmysqld-libs", no_argument, 0, 'm' },
-  {"embedded-libs", no_argument, 0, 'm' },
-  {"embedded", no_argument, 0, 'm' },
-#endif
   {NULL, 0, 0, 0}
 };
 
@@ -54,12 +46,7 @@ static const char *values[]=
   SOCKET,
   PORT,
   PLUGIN_DIR,
-  TLS_LIBRARY_VERSION,
-#ifdef HAVE_EMBEDDED
-  EMBED_LIBS,
-  EMBED_LIBS,
-  EMBED_LIBS,
-#endif
+  TLS_LIBRARY_VERSION
 };
 
 void usage(void)
@@ -128,11 +115,6 @@ int main(int argc, char **argv)
     case 'l':
       puts(LIBS_SYS);
       break;
-#ifdef HAVE_EMBEDDED
-    case 'm':
-      puts(EMBED_LIBS);
-      break;
-#endif
     default:
       exit((c != -1));
     }


### PR DESCRIPTION
Reverts MariaDB/mariadb-connector-c#109
I didn't see it's master (which isn't in use anymore)  - can you please add the changes in 3.0 branch? We will merge it in 3.1 afterwards