### PR TITLE
Fixed missing const qualifier

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -3757,7 +3757,7 @@ my_bool mariadb_get_infov(MYSQL *mysql, enum mariadb_value value, void *arg, ...
 #ifdef HAVE_TLS
     *((const char **)arg)= tls_library_version;
 #else
-    *((char **)arg)= "Off";
+    *((const char **)arg)= "Off";
 #endif
     break;
   case MARIADB_CLIENT_VERSION:


### PR DESCRIPTION
GCC:
```
mariadb-connector-c/libmariadb/mariadb_lib.c:3727:20: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
     *((char **)arg)= "Off";
                    ^
```
Not sure if merging into 3.1 branch is correct?