### PR TITLE
Compatibility with MySQL server 8.0

### DIFF
--- a/plugins/auth/caching_sha2_pw.c
+++ b/plugins/auth/caching_sha2_pw.c
@@ -275,14 +275,6 @@ static int auth_caching_sha2_client(MYSQL_PLUGIN_VIO *vio, MYSQL *mysql)
   memmove(mysql->scramble_buff, packet, SCRAMBLE_LENGTH);
   mysql->scramble_buff[SCRAMBLE_LENGTH]= 0;
 
-  /* if a tls session is active we need to send plain password */
-  if (mysql->client_flag & CLIENT_SSL)
-  {
-    if (vio->write_packet(vio, (unsigned char *)mysql->passwd, (int)strlen(mysql->passwd) + 1))
-      return CR_ERROR;
-    return CR_OK;
-  }
-
   /* send empty packet if no password was provided */
   if (!mysql->passwd || !mysql->passwd[0])
   {


### PR DESCRIPTION
Fixed caching_sha2_password plugin behaviour when SSL is enabled.
Currently, when password is non-empty and ssl is enabled, MariaDB connector sends a password as a plaintext before Fast Authentication, and server responds with an [error](https://github.com/mysql/mysql-server/blob/8.0/sql/auth/sha2_password.cc#L1003) as it expects the client to perform Fast Authentication by sending a scramble of size of SHA256.
[Caching SHA2 description](https://dev.mysql.com/doc/dev/mysql-server/latest/page_caching_sha2_authentication_exchanges.html#sect_caching_sha2_definition)
