### PR TITLE
gssapi: fix include path for Solaris

### DIFF
--- a/plugins/auth/gssapi_errmsg.c
+++ b/plugins/auth/gssapi_errmsg.c
@@ -26,7 +26,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifdef  __FreeBSD__
+#if defined(__FreeBSD__) ||  defined(SOLARIS) || defined(__sun)
 #include <gssapi/gssapi.h>
 #else
 #include <gssapi.h>


### PR DESCRIPTION
tested on:

uname -a
SunOS openindiana 5.11 illumos-b97b1727bc i86pc i386 i86pc

I submit this under the MCA.