### PR TITLE
CONC-456: Introduce INSTALL_PLUGINDIR_CLIENT

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -14,7 +14,7 @@
 #
 #
 # The following va+riables are used and can be overwritten
-# 
+#
 # INSTALL_LAYOUT     installation layout (DEFAULT = standard for tar.gz and zip packages
 #                                         RPM packages
 #
@@ -29,7 +29,7 @@ ENDIF()
 SET(INSTALL_LAYOUT ${INSTALL_LAYOUT} CACHE
   STRING "Installation layout. Currently supported options are DEFAULT (tar.gz and zip), RPM and DEB")
 
-# On Windows we only provide zip and .msi. Latter one uses a different packager. 
+# On Windows we only provide zip and .msi. Latter one uses a different packager.
 IF(UNIX)
   IF(INSTALL_LAYOUT MATCHES "RPM")
     SET(libmariadb_prefix "/usr")
@@ -92,15 +92,14 @@ SET(LIBMARIADB_STATIC_RPM "mariadbclient")
 #
 SET(INSTALL_BINDIR_DEB "bin")
 SET(INSTALL_LIBDIR_DEB "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
-SET(INSTALL_PCDIR_DEB "lib/pkgconfig")
-IF(PLUGINDIR_DEB)
-  SET(INSTALL_PLUGINDIR_DEB "${INSTALL_LIBDIR_DEB}/${PLUGINDIR_DEB}/plugin")
-ELSE()
-  SET(INSTALL_PLUGINDIR_DEB "${INSTALL_LIBDIR_DEB}/mariadb${CPACK_PACKAGE_VERSION_MAJOR}/plugin")
-ENDIF()
+SET(INSTALL_PCDIR_DEB "lib/${CMAKE_LIBRARY_ARCHITECTURE}/pkgconfig")
+SET(INSTALL_PLUGINDIR_DEB "${INSTALL_LIBDIR_DEB}/libmariadb${CPACK_PACKAGE_VERSION_MAJOR}/plugin")
 SET(INSTALL_INCLUDEDIR_DEB "include/mariadb")
 SET(LIBMARIADB_STATIC_DEB "mariadb")
 
+IF(INSTALL_LAYOUT MATCHES "DEB")
+  SET(INSTALL_PLUGINDIR_CLIENT ${INSTALL_PLUGINDIR_DEB})
+ENDIF()
 
 
 #
@@ -116,6 +115,11 @@ ENDIF()
 
 IF(INSTALL_PLUGINDIR)
   SET(INSTALL_PLUGINDIR_${INSTALL_LAYOUT} ${INSTALL_PLUGINDIR})
+ENDIF()
+
+# Extra INSTALL_PLUGINDIR_CLIENT that overrides any INSTALL_PLUGINDIR override
+IF(INSTALL_PLUGINDIR_CLIENT)
+  SET(INSTALL_PLUGINDIR_${INSTALL_LAYOUT} ${INSTALL_PLUGINDIR_CLIENT})
 ENDIF()
 
 IF(INSTALL_INCLUDEDIR)
@@ -139,7 +143,10 @@ ENDIF()
 FOREACH(dir "BIN" "LIB" "PC" "INCLUDE" "DOCS"  "PLUGIN")
   SET(INSTALL_${dir}DIR ${INSTALL_${dir}DIR_${INSTALL_LAYOUT}})
   MARK_AS_ADVANCED(INSTALL_${dir}DIR)
+  MESSAGE(STATUS "MariaDB Connector C: INSTALL_${dir}DIR=${INSTALL_${dir}DIR}")
 ENDFOREACH()
 
 SET(LIBMARIADB_STATIC_NAME ${LIBMARIADB_STATIC_${INSTALL_LAYOUT}})
 MARK_AS_ADVANCED(LIBMARIADB_STATIC_NAME)
+
+MESSAGE(STATUS "MariaDB Connector C: LIBMARIADB_STATIC_NAME ${LIBMARIADB_STATIC_NAME}")


### PR DESCRIPTION
If there is a INSTALL_PLUGINDIR_CLIENT it will override whatever value
INSTALL_PLUGINDIR had. This is useful in MariaDB Server builds where this
repository exists as a git submodule in directory libmariadb/.

Normally, when a INSTALL_PLUGINDIR is set (which happens in the server) it
will override whatever values are in the client library. The client
library does define its own layout for INSTALL_LAYOUT=DEB, but it is
near useless, since the values are the same as in the default, apart for
INSTALL_LIBDIR, which points to /usr/lib/<arch>/libmariadb3/plugins, but
is overridden. With this new flag, it will not be overridden, and will
actually be set as we want it to be in new Debian builds.

Why /usr/lib/<arch>/libmariadb3/plugins?
- <arch>, e.g. x86_64-linux-gnu, is needed to allow co-installation of
  32-bit and 64-bit on Debian, and is relevant for libmariadb3 pacakge.
- The "libmariadb" part separates these client library plugins from the
  server plugins, which are now in /usr/lib/*/mysql/plugins, but likely
  in /usr/lib/*/mariadb/plugins in the future, and at that point we don't
  want them to get mixed with the client ones.
- The "3" in in "libmariadb3/plugins" is needed since the libmariadb3 can
  in far future be co-installed with package libmariadb4, since there could
  be on a running system programs built either against libmariadb3 or
  libmariadb4, at least during some transitioning period. When different
  versions of a package are co-installable, both the pacakge name and the
  file paths need to have a version component.
  Note that package libmariadb-dev does not have a version nor versioned
  paths, as for any given point in time when new builds are made, they
  are always made against the latest library version.

In addition, the PLUGINDIR_DEB option is removed since to our knowledge
nothing ever used it and it is thus obsolete.

Is this backwards compatible?
- Since the next release will be 3.1.8 (a minor release) all changes need
  to be fully backwards compatible.
- The version 3.1.8 will be included in all new MariaDB versions 10.2,
  10.3, 10.4 and 10.5. Of these, only 10.5 is under development and allows
  functional changes to be made. This means, that only in MariaD 10.5 there
  can be paths changed. Since this is a new option introduced, and in 10.5
  the option to use CONC_INSTALL_LAYOUT=DEB will be introduced, this code
  path is only active in MariaDB 10.5 and later with MariaDB Connector C
  3.1.8 or later. This has no effect on 10.2, 10.3 and 10.4, and is thus
  safe to apply.

This also fixes CONC-304, which was partially already fixed, but never
applied in server builds due to the same buggy build flag handling.

In addition, some line ending whitespace was removed.

Change tested with full builds of both the client and server and comparing
full deb file listings:

```
$ diff -u filelist-ad1a0660dfd.log filelist-1f57e8a0f64.log
--- filelist-ad1a0660dfd.log	2020-03-26 22:04:19.821001386 +0200
+++ filelist-1f57e8a0f64.log	2020-03-27 00:02:12.156576964 +0200
@@ -2,13 +2,13 @@
 drwxr-xr-x root/root ./
 drwxr-xr-x root/root ./usr/
 drwxr-xr-x root/root ./usr/lib/
-drwxr-xr-x root/root ./usr/lib/mysql/
-drwxr-xr-x root/root ./usr/lib/mysql/plugin/
--rw-r--r-- root/root ./usr/lib/mysql/plugin/client_ed25519.so
--rw-r--r-- root/root ./usr/lib/mysql/plugin/dialog.so
--rw-r--r-- root/root ./usr/lib/mysql/plugin/mysql_clear_password.so
--rw-r--r-- root/root ./usr/lib/mysql/plugin/sha256_password.so
 drwxr-xr-x root/root ./usr/lib/x86_64-linux-gnu/
+drwxr-xr-x root/root ./usr/lib/x86_64-linux-gnu/libmariadb3/
+drwxr-xr-x root/root ./usr/lib/x86_64-linux-gnu/libmariadb3/plugin/
+-rw-r--r-- root/root ./usr/lib/x86_64-linux-gnu/libmariadb3/plugin/client_ed25519.so
+-rw-r--r-- root/root ./usr/lib/x86_64-linux-gnu/libmariadb3/plugin/dialog.so
+-rw-r--r-- root/root ./usr/lib/x86_64-linux-gnu/libmariadb3/plugin/mysql_clear_password.so
+-rw-r--r-- root/root ./usr/lib/x86_64-linux-gnu/libmariadb3/plugin/sha256_password.so
 -rw-r--r-- root/root ./usr/lib/x86_64-linux-gnu/libmariadb.so.3
 drwxr-xr-x root/root ./usr/share/
 drwxr-xr-x root/root ./usr/share/doc/
@@ -514,7 +514,8 @@
 -rw-r--r-- root/root ./usr/include/mariadb/server/typelib.h
 drwxr-xr-x root/root ./usr/lib/
 drwxr-xr-x root/root ./usr/lib/x86_64-linux-gnu/
--rw-r--r-- root/root ./usr/lib/x86_64-linux-gnu/libmariadbclient.a
+-rw-r--r-- root/root ./usr/lib/x86_64-linux-gnu/libmariadb.a
+lrwxrwxrwx root/root ./usr/lib/x86_64-linux-gnu/libmariadbclient.a
 lrwxrwxrwx root/root ./usr/lib/x86_64-linux-gnu/libmariadbclient.so
 lrwxrwxrwx root/root ./usr/lib/x86_64-linux-gnu/libmariadb.so
 -rw-r--r-- root/root ./usr/lib/x86_64-linux-gnu/libmysqlservices.a
@@ -741,9 +742,10 @@
 drwxr-xr-x root/root ./
 drwxr-xr-x root/root ./usr/
 drwxr-xr-x root/root ./usr/lib/
-drwxr-xr-x root/root ./usr/lib/mysql/
-drwxr-xr-x root/root ./usr/lib/mysql/plugin/
--rw-r--r-- root/root ./usr/lib/mysql/plugin/auth_gssapi_client.so
+drwxr-xr-x root/root ./usr/lib/x86_64-linux-gnu/
+drwxr-xr-x root/root ./usr/lib/x86_64-linux-gnu/libmariadb3/
+drwxr-xr-x root/root ./usr/lib/x86_64-linux-gnu/libmariadb3/plugin/
+-rw-r--r-- root/root ./usr/lib/x86_64-linux-gnu/libmariadb3/plugin/auth_gssapi_client.so
 drwxr-xr-x root/root ./usr/share/
 drwxr-xr-x root/root ./usr/share/doc/
 drwxr-xr-x root/root ./usr/share/doc/mariadb-plugin-gssapi-client/
```

The MariaDB Server part will be fixed in MDEV-22053.

When and in what order can this be rolled out?
- This change only affects server builds once the MDEV-22053 is fixed, so
  this can be merged on the MariaDB Connector C at any time.
- The server MDEV-22053 can be fixed at any time, as it only starts to
  apply to the server once MariaDB Connector C 3.1.8 is released _and_
  the MariaDB Server source code submodule libmariadb is updated, at which
  point the Debian packaging is affected and needs to be updated.

Are there resources to carry out this change?
- Otto made this change and will also fix MDEV-22053.
- Otto will update MariaDB Server 10.5 packaging as soon as MariaDB
  Connector C 3.1.8 is out and updated as submodule in server.