### PR TITLE
Implement CLIENT_DEPRECATE_EOF for mariadb-connector-c

### DIFF
--- a/include/ma_common.h
+++ b/include/ma_common.h
@@ -23,6 +23,8 @@
 #include <mysql.h>
 #include <ma_hash.h>
 
+#define MAX_PACKET_LENGTH (256L*256L*256L-1)
+
 enum enum_multi_status {
   COM_MULTI_OFF= 0,
   COM_MULTI_CANCEL,

--- a/include/mariadb_com.h
+++ b/include/mariadb_com.h
@@ -160,6 +160,7 @@ enum enum_server_command
 #define CLIENT_CONNECT_ATTRS     (1UL << 20)
 #define CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS (1UL << 22)
 #define CLIENT_SESSION_TRACKING  (1UL << 23)
+#define CLIENT_DEPRECATE_EOF     (1UL << 24)
 #define CLIENT_PROGRESS          (1UL << 29) /* client supports progress indicator */
 #define CLIENT_PROGRESS_OBSOLETE  CLIENT_PROGRESS 
 #define CLIENT_SSL_VERIFY_SERVER_CERT (1UL << 30)
@@ -204,6 +205,7 @@ enum enum_server_command
                                  CLIENT_REMEMBER_OPTIONS |\
                                  CLIENT_PLUGIN_AUTH |\
                                  CLIENT_SESSION_TRACKING |\
+                                 CLIENT_DEPRECATE_EOF |\
                                  CLIENT_CONNECT_ATTRS)
 
 #define CLIENT_CAPABILITIES	(CLIENT_MYSQL | \
@@ -215,6 +217,7 @@ enum enum_server_command
                                  CLIENT_PROTOCOL_41 |\
                                  CLIENT_PLUGIN_AUTH |\
                                  CLIENT_SESSION_TRACKING |\
+                                 CLIENT_DEPRECATE_EOF |\
                                  CLIENT_CONNECT_ATTRS)
 
 #define CLIENT_DEFAULT_FLAGS ((CLIENT_SUPPORTED_FLAGS & ~CLIENT_COMPRESS)\

--- a/include/mariadb_stmt.h
+++ b/include/mariadb_stmt.h
@@ -257,7 +257,7 @@ typedef struct st_mysql_perm_bind {
 } MYSQL_PS_CONVERSION;
 
 extern MYSQL_PS_CONVERSION mysql_ps_fetch_functions[MYSQL_TYPE_GEOMETRY + 1];
-unsigned long ma_net_safe_read(MYSQL *mysql);
+unsigned long ma_net_safe_read(MYSQL *mysql, my_bool *is_data_packet);
 void mysql_init_ps_subsystem(void);
 unsigned long net_field_length(unsigned char **packet);
 int ma_simple_command(MYSQL *mysql,enum enum_server_command command, const char *arg,

--- a/libmariadb/ma_net.c
+++ b/libmariadb/ma_net.c
@@ -39,8 +39,6 @@
 #include <poll.h>
 #endif
 
-#define MAX_PACKET_LENGTH (256L*256L*256L-1)
-
 /* net_buffer_length and max_allowed_packet are defined in mysql.h
    See bug conc-57
  */

--- a/libmariadb/mariadb_rpl.c
+++ b/libmariadb/mariadb_rpl.c
@@ -122,7 +122,7 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
     return 0;
 
   while (1) {
-    unsigned long pkt_len= ma_net_safe_read(rpl->mysql);
+    unsigned long pkt_len= ma_net_safe_read(rpl->mysql, NULL);
 
     if (pkt_len == packet_error)
     {

--- a/plugins/auth/my_auth.c
+++ b/plugins/auth/my_auth.c
@@ -401,7 +401,7 @@ static int client_mpvio_read_packet(struct st_plugin_vio *mpv, uchar **buf)
   }
 
   /* otherwise read the data */
-  if ((pkt_len= ma_net_safe_read(mysql)) == packet_error)
+  if ((pkt_len= ma_net_safe_read(mysql, NULL)) == packet_error)
     return (int)packet_error;
 
   mpvio->last_read_packet_len= pkt_len;
@@ -619,7 +619,7 @@ retry:
 
   /* read the OK packet (or use the cached value in mysql->net.read_pos */
   if (res == CR_OK)
-    pkt_length= ma_net_safe_read(mysql);
+    pkt_length= ma_net_safe_read(mysql, NULL);
   else /* res == CR_OK_HANDSHAKE_COMPLETE or an error */
     pkt_length= mpvio.last_read_packet_len;
 

--- a/unittest/libmariadb/ps_bugs.c
+++ b/unittest/libmariadb/ps_bugs.c
@@ -3931,6 +3931,10 @@ static int test_conc141(MYSQL *mysql)
 
   rc= mysql_stmt_execute(stmt);
   check_stmt_rc(rc, stmt);
+
+  rc= mysql_stmt_free_result(stmt);
+  check_stmt_rc(rc, stmt);
+
   /* skip first result */
   rc= mysql_stmt_next_result(stmt);
   FAIL_IF(rc==-1, "No more results and error expected");

--- a/unittest/libmariadb/ps_new.c
+++ b/unittest/libmariadb/ps_new.c
@@ -105,6 +105,10 @@ static int test_multi_result(MYSQL *mysql)
  
   FAIL_IF(int_data[0] != 10 || int_data[1] != 20 || int_data[2] != 30,
           "expected 10 20 30");
+
+  rc= mysql_stmt_free_result(stmt); // must call before next mysql_stmt_next_result
+  check_stmt_rc(rc, stmt);
+
   rc= mysql_stmt_next_result(stmt);
   check_stmt_rc(rc, stmt);
   rc= mysql_stmt_bind_result(stmt, rs_bind);
@@ -114,6 +118,9 @@ static int test_multi_result(MYSQL *mysql)
   FAIL_IF(int_data[0] != 100 || int_data[1] != 200 || int_data[2] != 300,
           "expected 100 200 300");
 
+  rc= mysql_stmt_free_result(stmt);
+  check_stmt_rc(rc, stmt);
+
   FAIL_IF(mysql_stmt_next_result(stmt) != 0, "expected more results");
   rc= mysql_stmt_bind_result(stmt, rs_bind);
 
@@ -121,6 +128,9 @@ static int test_multi_result(MYSQL *mysql)
   FAIL_IF(mysql_stmt_field_count(stmt) != 2, "expected 2 fields");
   FAIL_IF(int_data[0] != 200 || int_data[1] != 300,
           "expected 100 200 300");
+
+  rc= mysql_stmt_free_result(stmt);
+  check_stmt_rc(rc, stmt);
   
   FAIL_IF(mysql_stmt_next_result(stmt) != 0, "expected more results");
   FAIL_IF(mysql_stmt_field_count(stmt) != 0, "expected 0 fields");


### PR DESCRIPTION
Fix for [CONC-461](https://jira.mariadb.org/browse/CONC-461)

mariadb-connector-c client now sends CLIENT_DEPRECATE_EOF flag to the server.

There are some major changes on how the server responds. Mainly the way packets are sent back from server changes which are documented in https://dev.mysql.com/worklog/task/?id=7766

I will try to add as much comment on the code changes as possible.

Note:

Most of the changes have been studied on the worklog, looking into the packets through wireshark and how mysql client behaves.