### PR TITLE
Shouldn't INSTALL mariadb_config honour INSTALL_BINDIR?

### DIFF
--- a/mariadb_config/CMakeLists.txt
+++ b/mariadb_config/CMakeLists.txt
@@ -55,7 +55,7 @@ ADD_EXECUTABLE(mariadb_config ${CMAKE_CURRENT_BINARY_DIR}/mariadb_config.c)
 # Installation
 #
 INSTALL(TARGETS mariadb_config
-        DESTINATION "bin"
+        DESTINATION "${INSTALL_BINDIR}"
         COMPONENT Development)
 
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libmariadb.pc


### PR DESCRIPTION
In `cmake/install.cmake` the comment explains that INSTALL_BINDIR is the location that mariadb_config is installed in.

In `mariadb_config/CMakeLists.txt` the INSTALL command has hard-coded "bin" as destination.

Changed hardcoded "bin" to "${INSTALL_BINDIR}".