### PR TITLE
MDEV-14811 unit.conc_misc fails in buildbot on bld-starfs-release in test_conc49

### DIFF
--- a/unittest/libmariadb/my_test.h
+++ b/unittest/libmariadb/my_test.h
@@ -453,7 +453,7 @@ int check_variable(MYSQL *mysql, const char *variable, const char *value)
 MYSQL *test_connect(struct my_tests_st *test)
 {
   MYSQL *mysql;
-  int i= 0;
+  int i= 0, rc;
   int timeout= 10;
   my_bool truncation_report= 1;
   if (!(mysql = mysql_init(NULL))) {
@@ -484,6 +484,16 @@ MYSQL *test_connect(struct my_tests_st *test)
     mysql_close(mysql);
     return(NULL);
   }
+
+  /* Clear sql_mode when establishing a new connection. */
+  rc= mysql_query(mysql, "SET sql_mode=''");
+  if (rc)
+  {
+    diag("Error (%d): %s (%d) in %s line %d", rc, mysql_error(mysql),
+         mysql_errno(mysql), __FILE__, __LINE__);
+    return(NULL);
+  }
+
   return(mysql);
 }
 


### PR DESCRIPTION
Make sure sql_mode is cleared when starting a new connection.

The problem:
When a test is skipped and there was an error in the last sql statement
sent on the default connection, the mysql_default connection is
recreated, but without sql_mode set to ''.

This leads to sql_mode having NO_ENGINE_SUBSTITUTION set.
test_conc49 tries to create an InnoDB table, but if the previous test
(in this particular case test_connect_attrs) is skipped and it errored
(in this case because it tried selecting from a performance schema
table that did not exist), it will recreate the mysql_default
connection via test_connect before running test_conc49.

Fix by making sure test_connect clears the sql_mode, just like
reset_connection, which is normally called between succesful test
runs.