### PR TITLE
[CONC-381] Fix strict prototypes warning

### DIFF
--- a/include/mysql.h
+++ b/include/mysql.h
@@ -459,7 +459,7 @@ typedef struct character_set
   const char *license;                                  \
   void *mariadb_api;                                    \
   int (*init)(char *, size_t, int, va_list);            \
-  int (*deinit)();                                      \
+  int (*deinit)(void);                                  \
   int (*options)(const char *option, const void *);
 struct st_mysql_client_plugin
 {


### PR DESCRIPTION
Projects compiled with `-Wstrict-prototypes` will emit a warning. C requires that functions with arguments be prototyped as foo(void), not foo(). This commit fixes the warning.

Issue originally reported here https://jira.mariadb.org/browse/CONC-381