### PR TITLE
Add Xpand to mysql_get_server_name

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -3865,13 +3865,19 @@ my_bool STDCALL mariadb_connection(MYSQL *mysql)
           strstr(mysql->server_version, "-maria-"));
 }
 
+static my_bool xpand_connection(MYSQL *mysql)
+{
+  return (strstr(mysql->server_version, "-xpand-") != NULL);
+}
+
 const char * STDCALL
 mysql_get_server_name(MYSQL *mysql)
 {
   if (mysql->options.extension &&
       mysql->options.extension->db_driver != NULL)
     return mysql->options.extension->db_driver->name;
-  return mariadb_connection(mysql) ? "MariaDB" : "MySQL";
+  return mariadb_connection(mysql) ? "MariaDB" :
+         xpand_connection(mysql) ? "Xpand" : "MySQL";
 }
 
 static my_socket mariadb_get_socket(MYSQL *mysql)

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -3867,7 +3867,7 @@ my_bool STDCALL mariadb_connection(MYSQL *mysql)
 
 static my_bool xpand_connection(MYSQL *mysql)
 {
-  return (strstr(mysql->server_version, "-xpand-") != NULL);
+  return (strstr(mysql->server_version, "-Xpand-") != NULL);
 }
 
 const char * STDCALL


### PR DESCRIPTION
When connecting to the Xpand backend with the mariadb command-line client, the default prompt says "MySQL> ". This can be confusing, so usually we recommend that people change it with the prompt command. But it would be nice if the client library simply knew that it was Xpand and not MySQL (or MariaDB).