### PR TITLE
Fix include on case-sensitive fs

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -74,7 +74,7 @@
 #endif
 #include <mysql/client_plugin.h>
 #ifdef _WIN32
-#include "Shlwapi.h"
+#include "shlwapi.h"
 #define strncasecmp _strnicmp
 #endif
 


### PR DESCRIPTION
shlwapi is lowercase on case-sensitive file-systems