### PR TITLE
[CONC-499] maxscale CI test addition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
     - env: DB=mariadb:10.2
     - env: DB=mariadb:10.3
     - env: DB=mariadb:10.4
+    - env: DB=mariadb:10.5
+    - env: DB=mariadb:10.5 MAXSCALE_VERSION=2.5.3 MAXSCALE_TEST_DISABLE=true
     - env: SERVER_BRANCH=10.2
     - env: SERVER_BRANCH=10.2 TEST_OPTION=--ps-protocol
     - env: SERVER_BRANCH=10.3

--- a/.travis/docker-compose.yml
+++ b/.travis/docker-compose.yml
@@ -9,5 +9,5 @@ services:
       - $SSLCERT:/etc/sslcert
       - $ENTRYPOINT:/docker-entrypoint-initdb.d
     environment:
-      MYSQL_DATABASE: test
+      MYSQL_DATABASE: ctest
       MYSQL_ALLOW_EMPTY_PASSWORD: 1

--- a/.travis/maxscale-compose.yml
+++ b/.travis/maxscale-compose.yml
@@ -1,0 +1,36 @@
+version: '2.1'
+services:
+  db:
+    image: $DB
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --ssl-ca=/etc/sslcert/ca.crt --ssl-cert=/etc/sslcert/server.crt --ssl-key=/etc/sslcert/server.key --bind-address=0.0.0.0
+    ports:
+      - 3305:3306
+    volumes:
+      - $SSLCERT:/etc/sslcert
+      - $ENTRYPOINT:/docker-entrypoint-initdb.d
+    environment:
+      MYSQL_DATABASE: ctest
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    healthcheck:
+      test: ["CMD", "mysql", "--protocol=tcp", "-ubob", "-h127.0.0.1"]
+      timeout: 50s
+      retries: 10
+      interval: 5s
+
+  maxscale:
+    depends_on:
+      db:
+        condition: service_healthy
+    links:
+      - "db:database"
+    ports:
+      - 4006:4006
+      - 4008:4008
+      - 4009:4009
+    volumes:
+      - $SSLCERT:/etc/sslcert
+    build:
+      context: .
+      dockerfile: maxscale/Dockerfile
+      args:
+        MAXSCALE_VERSION: $MAXSCALE_VERSION

--- a/.travis/maxscale/Dockerfile
+++ b/.travis/maxscale/Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:7
+
+ARG MAXSCALE_VERSION
+ENV MAXSCALE_VERSION ${MAXSCALE_VERSION:-2.5.3}
+
+COPY maxscale/mariadb.repo /etc/yum.repos.d/
+
+RUN rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB \
+    && yum -y install https://downloads.mariadb.com/MaxScale/${MAXSCALE_VERSION}/centos/7/x86_64/maxscale-${MAXSCALE_VERSION}-2.rhel.7.x86_64.rpm \
+    && yum -y update
+
+RUN yum -y install maxscale-${MAXSCALE_VERSION} MariaDB-client \
+    && yum clean all \
+    && rm -rf /tmp/*
+
+COPY maxscale/docker-entrypoint.sh /
+COPY maxscale/maxscale.cnf /etc/
+RUN chmod 777 /etc/maxscale.cnf
+RUN chmod 777 /docker-entrypoint.sh
+
+
+EXPOSE 4006 4007 4008
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/.travis/maxscale/docker-entrypoint.sh
+++ b/.travis/maxscale/docker-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo 'creating configuration done'
+
+sleep 15
+
+#################################################################################################
+# wait for db availability for 60s
+#################################################################################################
+mysql=( mysql --protocol=tcp -ubob -hdb --port=3306 )
+for i in {60..0}; do
+    if echo 'use ctest' | "${mysql[@]}" &> /dev/null; then
+        break
+    fi
+    echo 'DB init process in progress...'
+    sleep 1
+done
+
+echo 'use ctest' | "${mysql[@]}"
+if [ "$i" = 0 ]; then
+    echo 'DB init process failed.'
+    exit 1
+fi
+
+echo 'maxscale launching ...'
+
+tail -n 500 /etc/maxscale.cnf
+
+/usr/bin/maxscale --user=root --nodaemon
+
+cd /var/log/maxscale
+ls -lrt
+tail -n 500 /var/log/maxscale/maxscale.log

--- a/.travis/maxscale/mariadb.repo
+++ b/.travis/maxscale/mariadb.repo
@@ -1,0 +1,7 @@
+# MariaDB 10.2 CentOS repository list - created 2017-06-05 08:06 UTC
+# http://downloads.mariadb.org/mariadb/repositories/
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/10.2/centos7-amd64
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1

--- a/.travis/maxscale/maxscale.cnf
+++ b/.travis/maxscale/maxscale.cnf
@@ -1,0 +1,121 @@
+# MaxScale documentation:
+# https://mariadb.com/kb/en/mariadb-maxscale-24/
+
+# Global parameters
+#
+# Complete list of configuration options:
+# https://mariadb.com/kb/en/mariadb-maxscale-24-mariadb-maxscale-configuration-guide/
+
+[maxscale]
+threads=auto
+
+# Server definitions
+#
+# Set the address of the server to the network
+# address of a MariaDB server.
+#
+
+[server2]
+type=server
+address=database
+port=3306
+protocol=MariaDBBackend
+ssl=true
+ssl_ca_cert=/etc/sslcert/server.crt
+ssl_cert=/etc/sslcert/client.crt
+ssl_key=/etc/sslcert/client.key
+
+
+[server1]
+type=server
+address=db
+port=3306
+protocol=MariaDBBackend
+
+
+# Monitor for the servers
+#
+# This will keep MaxScale aware of the state of the servers.
+# MariaDB Monitor documentation:
+# https://mariadb.com/kb/en/mariadb-maxscale-24-mariadb-monitor/
+
+[MariaDB-Monitor]
+type=monitor
+module=mariadbmon
+servers=server1
+user=boby
+password=hey
+monitor_interval=2000
+
+[MariaDB-Monitor2]
+type=monitor
+module=mariadbmon
+servers=server2
+user=boby
+password=hey
+monitor_interval=2000
+
+# Service definitions
+#
+# Service Definition for a read-only service and
+# a read/write splitting service.
+#
+
+# ReadConnRoute documentation:
+# https://mariadb.com/kb/en/mariadb-maxscale-24-readconnroute/
+
+[Read-Only-Service]
+type=service
+router=readconnroute
+servers=server1
+user=boby
+password=hey
+router_options=slave
+
+# ReadWriteSplit documentation:
+# https://mariadb.com/kb/en/mariadb-maxscale-24-readwritesplit/
+
+[Read-Write-Service]
+type=service
+router=readwritesplit
+servers=server1
+version_string=10.5.99-MariaDB-maxScale
+user=boby
+password=hey
+
+[Read-Write-Service2]
+type=service
+router=readwritesplit
+version_string=10.5.99-MariaDB-maxScale
+servers=server2
+user=boby
+password=hey
+
+# Listener definitions for the services
+#
+# These listeners represent the ports the
+# services will listen on.
+#
+
+[Read-Only-Listener]
+type=listener
+service=Read-Only-Service
+protocol=MariaDBClient
+port=4008
+
+[Read-Write-Listener]
+type=listener
+service=Read-Write-Service
+protocol=MariaDBClient
+port=4006
+
+
+[Read-Write-Listener2]
+type=listener
+service=Read-Write-Service2
+protocol=MariaDBClient
+port=4009
+ssl=true
+ssl_ca_cert=/etc/sslcert/ca.crt
+ssl_cert=/etc/sslcert/server.crt
+ssl_key=/etc/sslcert/server.key

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -6,7 +6,7 @@ set -e
 ###################################################################################################################
 # test different type of configuration
 ###################################################################################################################
-mysql=( mysql --protocol=tcp -ubob -h127.0.0.1 --port=3305 )
+export MYSQL_TEST_TRAVIS=1
 
 if [ -n "$SKYSQL" ] ; then
 
@@ -14,55 +14,67 @@ if [ -n "$SKYSQL" ] ; then
     echo "No SkySQL configuration found !"
     exit 1
   fi
-
   export MYSQL_TEST_USER=$SKYSQL_TEST_USER
   export MYSQL_TEST_HOST=$SKYSQL_TEST_HOST
   export MYSQL_TEST_PASSWD=$SKYSQL_TEST_PASSWORD
   export MYSQL_TEST_PORT=$SKYSQL_TEST_PORT
   export MYSQL_TEST_DATABASE=$SKYSQL_TEST_DATABASE
   export MYSQL_TEST_TLS=1
-else
-  export COMPOSE_FILE=.travis/docker-compose.yml
 
+else
+
+  export COMPOSE_FILE=.travis/docker-compose.yml
+  export MYSQL_TEST_HOST=mariadb.example.com
+  export MYSQL_TEST_DB=ctest
+  export MYSQL_TEST_USER=bob
+  export MYSQL_TEST_PORT=3305
+
+  export MARIADB_PLUGIN_DIR=$PWD
+
+  if [ -n "$MAXSCALE_VERSION" ] ; then
+      # maxscale ports:
+      # - non ssl: 4006
+      # - ssl: 4009
+      export MYSQL_TEST_PORT=4006
+      export MYSQL_TEST_SSL_PORT=4009
+      export COMPOSE_FILE=.travis/maxscale-compose.yml
+      docker-compose -f ${COMPOSE_FILE} build
+  fi
+
+  mysql=( mysql --protocol=TCP -u${MYSQL_TEST_USER} -h${MYSQL_TEST_HOST} --port=${MYSQL_TEST_PORT} ${MYSQL_TEST_DB})
 
   ###################################################################################################################
   # launch docker server and maxscale
   ###################################################################################################################
-  export INNODB_LOG_FILE_SIZE=$(echo ${PACKET}| cut -d'M' -f 1)0M
-  docker-compose -f ${COMPOSE_FILE} build
   docker-compose -f ${COMPOSE_FILE} up -d
-
 
   ###################################################################################################################
   # wait for docker initialisation
   ###################################################################################################################
 
-  for i in {60..0}; do
+  for i in {30..0}; do
     if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
         break
     fi
     echo 'data server still not active'
-    sleep 1
+    sleep 2
   done
 
-  docker-compose -f ${COMPOSE_FILE} logs
-
   if [ "$i" = 0 ]; then
-    echo 'SELECT 1' | "${mysql[@]}"
+    if echo 'SELECT 1' | "${mysql[@]}" ; then
+        break
+    fi
+
+    docker-compose -f ${COMPOSE_FILE} logs
+    if [ -n "$MAXSCALE_VERSION" ] ; then
+        docker-compose -f ${COMPOSE_FILE} exec maxscale tail -n 500 /var/log/maxscale/maxscale.log
+    fi
     echo >&2 'data server init process failed.'
     exit 1
   fi
 
   #list ssl certificates
   ls -lrt ${SSLCERT}
-
-
-  export MYSQL_TEST_HOST=mariadb.example.com
-  export MYSQL_TEST_DB=ctest
-  export MYSQL_TEST_USER=bob
-  export MYSQL_TEST_PORT=3305
-  export MYSQL_TEST_TRAVIS=1
-  export MARIADB_PLUGIN_DIR=$PWD
 
 fi
 

--- a/.travis/sql/dbinit.sql
+++ b/.travis/sql/dbinit.sql
@@ -1,6 +1,15 @@
+CREATE USER 'bob'@'localhost';
+GRANT ALL ON *.* TO 'bob'@'localhost' with grant option;
+
 CREATE USER 'bob'@'%';
 GRANT ALL ON *.* TO 'bob'@'%' with grant option;
 
+CREATE USER 'boby'@'%' identified by 'hey';
+GRANT ALL ON *.* TO 'boby'@'%' identified by 'hey' with grant option;
+
+CREATE USER 'boby'@'localhost' identified by 'hey';
+GRANT ALL ON *.* TO 'boby'@'localhost' identified by 'hey' with grant option;
+
 FLUSH PRIVILEGES;
 
-CREATE DATABASE ctest;
+CREATE DATABASE test;

--- a/unittest/libmariadb/basic-t.c
+++ b/unittest/libmariadb/basic-t.c
@@ -38,6 +38,7 @@ static int test_conc75(MYSQL *my)
   my_bool reconnect= 1;
 
   SKIP_SKYSQL;
+  SKIP_MAXSCALE;
 
   mysql= mysql_init(NULL);
 
@@ -147,6 +148,7 @@ static int test_conc70(MYSQL *my)
   SKIP_CONNECTION_HANDLER;
 
   SKIP_SKYSQL;
+  SKIP_MAXSCALE;
 
   mysql= mysql_init(NULL);
 
@@ -210,7 +212,7 @@ static int test_conc68(MYSQL *my)
 
   SKIP_CONNECTION_HANDLER;
   SKIP_SKYSQL;
-
+  SKIP_MAXSCALE;
   
   mysql= mysql_init(NULL);
 

--- a/unittest/libmariadb/charset.c
+++ b/unittest/libmariadb/charset.c
@@ -513,8 +513,8 @@ static int bug30472_retrieve_charset_info(MYSQL *con,
 
 static int test_bug30472(MYSQL *mysql)
 {
+  SKIP_MAXSCALE
   int   rc;
-
   char character_set_name_1[MY_CS_NAME_SIZE];
   char character_set_client_1[MY_CS_NAME_SIZE];
   char character_set_results_1[MY_CS_NAME_SIZE];

--- a/unittest/libmariadb/connection.c
+++ b/unittest/libmariadb/connection.c
@@ -35,6 +35,7 @@ static int test_conc66(MYSQL *my)
   char query[1024];
 
   SKIP_SKYSQL;
+  SKIP_MAXSCALE;
 
   if (!is_mariadb)
     return SKIP;
@@ -91,6 +92,7 @@ static int test_bug20023(MYSQL *mysql)
   int rc;
 
   SKIP_SKYSQL;
+  SKIP_MAXSCALE;
 
   if (!is_mariadb)
     return SKIP;
@@ -527,6 +529,8 @@ static int test_opt_reconnect(MYSQL *mysql)
 
 static int test_compress(MYSQL *mysql)
 {
+  // maxscale doesn't support compression
+  SKIP_MAXSCALE
   MYSQL_RES *res;
   MYSQL_ROW row;
   int rc;
@@ -606,6 +610,7 @@ static int test_reconnect(MYSQL *mysql)
 
 int test_conc21(MYSQL *mysql)
 {
+  SKIP_MAXSCALE
   int rc;
   MYSQL_RES *res= NULL;
   MYSQL_ROW row;
@@ -679,6 +684,7 @@ int test_connection_timeout2(MYSQL *unused __attribute__((unused)))
   MYSQL *mysql;
 
   SKIP_SKYSQL;
+  SKIP_MAXSCALE;
 
   mysql= mysql_init(NULL);
   mysql_options(mysql, MYSQL_OPT_CONNECT_TIMEOUT, (unsigned int *)&timeout);
@@ -1136,6 +1142,7 @@ static int test_auth256(MYSQL *my)
   my_ulonglong num_rows= 0;
   char query[1024];
 
+  SKIP_MAXSCALE
   if (IS_SKYSQL(hostname))
     return SKIP;
 
@@ -1671,6 +1678,7 @@ static int test_conc366(MYSQL *mysql)
   MYSQL *my;
 
   SKIP_SKYSQL;
+  SKIP_MAXSCALE;
 
   if (!is_mariadb)
   {

--- a/unittest/libmariadb/misc.c
+++ b/unittest/libmariadb/misc.c
@@ -1000,6 +1000,7 @@ static int test_conc117(MYSQL *unused __attribute__((unused)))
 
 static int test_read_timeout(MYSQL *unused __attribute__((unused)))
 {
+  SKIP_MAXSCALE
   int timeout= 5, rc;
   MYSQL *my= mysql_init(NULL);
   mysql_options(my, MYSQL_OPT_READ_TIMEOUT, &timeout);

--- a/unittest/libmariadb/my_test.h
+++ b/unittest/libmariadb/my_test.h
@@ -63,6 +63,14 @@ if (IS_SKYSQL(hostname)) \
   return SKIP; \
 }       
 
+#define IS_MAXSCALE() (getenv("MAXSCALE_TEST_DISABLE")!=NULL)
+#define SKIP_MAXSCALE \
+if (IS_MAXSCALE()) \
+{ \
+  diag("test disabled with maxscale"); \
+  return SKIP; \
+}
+
 #define MAX_KEY MAX_INDEXES
 #define MAX_KEY_LENGTH_DECIMAL_WIDTH 4          /* strlen("4096") */
 
@@ -173,6 +181,7 @@ static const char *schema = 0;
 static char *hostname = 0;
 static char *password = 0;
 static unsigned int port = 0;
+static unsigned int ssl_port = 0;
 static char *socketname = 0;
 static char *username = 0;
 static int force_tls= 0;
@@ -413,6 +422,7 @@ void get_options(int argc, char **argv)
       break;
     case 'P':
       port= atoi(optarg);
+      ssl_port=port;
       break;
     case 'S':
       socketname= optarg;
@@ -508,7 +518,7 @@ MYSQL *test_connect(struct my_tests_st *test)
 static int reset_connection(MYSQL *mysql) {
   int rc;
 
-  if (is_mariadb)
+  if (is_mariadb && !IS_MAXSCALE())
     rc= mysql_change_user(mysql, username, password, schema);
   else
     rc= mysql_reset_connection(mysql);
@@ -555,6 +565,15 @@ void get_envvars() {
       port= atoi(envvar);
     diag("port: %d", port);
   }
+  if (!ssl_port)
+  {
+    if ((envvar= getenv("MYSQL_TEST_SSL_PORT")))
+      ssl_port= atoi(envvar);
+    else
+      ssl_port = port;
+    diag("ssl_port: %d", ssl_port);
+  }
+
   if (!force_tls && (envvar= getenv("MYSQL_TEST_TLS")))
     force_tls= atoi(envvar);
   if (!socketname)

--- a/unittest/libmariadb/ps.c
+++ b/unittest/libmariadb/ps.c
@@ -49,6 +49,7 @@ static int test_conc97(MYSQL *mysql)
 
 static int test_conc83(MYSQL *unused __attribute__((unused)))
 {
+  SKIP_MAXSCALE
   MYSQL_STMT *stmt;
   int rc;
   MYSQL *mysql= mysql_init(NULL);

--- a/unittest/libmariadb/ssl.c
+++ b/unittest/libmariadb/ssl.c
@@ -140,7 +140,7 @@ static int test_ssl(MYSQL *mysql)
   create_ssl_user("ssluser", 0);
 
   FAIL_IF(!mysql_real_connect(my, hostname, ssluser, sslpw, schema,
-                         port, socketname, 0), mysql_error(my));
+                         ssl_port, socketname, 0), mysql_error(my));
 
   mariadb_get_infov(my, MARIADB_CONNECTION_TLS_VERSION_ID, &iversion);
   diag("iversion: %d", iversion);
@@ -221,7 +221,7 @@ static int test_ssl_cipher(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(my,0, 0, sslca, 0, 0);
 
   FAIL_IF(!mysql_real_connect(my, hostname, ssluser, sslpw, schema,
-                         port, socketname, 0), mysql_error(my));
+                         ssl_port, socketname, 0), mysql_error(my));
 
   rc= mysql_query(my, "SHOW session status like 'Ssl_version'");
   check_mysql_rc(rc, my);
@@ -254,7 +254,7 @@ static int test_conc95(MYSQL *unused __attribute__((unused)))
                 NULL);
 
   if (!mysql_real_connect(mysql, hostname, "ssluser1", sslpw, schema,
-                          port, socketname, 0))
+                          ssl_port, socketname, 0))
   {
     diag("could not establish x509 connection. Error: %s", mysql_error(mysql));
     mysql_close(mysql);
@@ -283,7 +283,7 @@ static int test_multi_ssl_connections(MYSQL *unused __attribute__((unused)))
   my= mysql_init(NULL);
   FAIL_IF(!my,"mysql_init() failed");
   FAIL_IF(!mysql_real_connect(my, hostname, ssluser, sslpw, schema,
-           port, socketname, 0), mysql_error(my));
+           ssl_port, socketname, 0), mysql_error(my));
 
   rc= mysql_query(my, "SHOW STATUS LIKE 'Ssl_accepts'");
   check_mysql_rc(rc, my);
@@ -301,7 +301,7 @@ static int test_multi_ssl_connections(MYSQL *unused __attribute__((unused)))
     mysql_ssl_set(mysql[i], 0, 0, sslca, 0, 0);
 
     mysql_real_connect(mysql[i], hostname, ssluser, sslpw, schema,
-                         port, socketname, 0);
+                         ssl_port, socketname, 0);
     if (mysql_errno(mysql[i]))
     {
       diag("loop: %d error: %d %s", i, mysql_errno(mysql[i]), mysql_error(mysql[i]));
@@ -345,7 +345,7 @@ DWORD WINAPI ssl_thread(void *dummy)
   mysql_ssl_set(mysql, 0, 0, sslca, 0, 0);
 
   if(!mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-          port, socketname, 0))
+          ssl_port, socketname, 0))
   {
     diag(">Error: %s", mysql_error(mysql));
     goto end;
@@ -435,7 +435,7 @@ static int test_phpbug51647(MYSQL *unused __attribute__((unused)))
                        sslca, 0, 0);
 
   FAIL_IF(!mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0), mysql_error(mysql));
+           ssl_port, socketname, 0), mysql_error(mysql));
   diag("%s", mysql_get_ssl_cipher(mysql));
   mysql_close(mysql);
 
@@ -459,7 +459,7 @@ static int test_password_protected(MYSQL *unused __attribute__((unused)))
   mysql_options(mysql, MARIADB_OPT_TLS_PASSPHRASE, "qwerty");
 
   FAIL_IF(!mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0), mysql_error(mysql));
+           ssl_port, socketname, 0), mysql_error(mysql));
   diag("%s", mysql_get_ssl_cipher(mysql));
   mysql_close(mysql);
 
@@ -480,7 +480,7 @@ static int test_conc50(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(mysql, NULL, NULL, "./non_exisiting_cert.pem", NULL, NULL);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   diag("Error: %d %s", mysql_errno(mysql), mysql_error(mysql));
   FAIL_IF(mysql_errno(mysql) != 2026, "Expected errno 2026");
   mysql_close(mysql);
@@ -509,7 +509,7 @@ static int test_conc50_1(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(mysql, NULL, NULL, sslca, NULL, NULL);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   if (mysql_errno(mysql))
     diag("Error: %d %s", mysql_errno(mysql), mysql_error(mysql));
   FAIL_IF(mysql_errno(mysql), "No error expected");
@@ -532,7 +532,7 @@ static int test_conc50_2(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(mysql, NULL, NULL, "./non_exisiting_cert.pem", NULL, NULL);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   FAIL_IF(mysql_errno(mysql) != 2026, "Expected errno 2026");
   mysql_close(mysql);
 
@@ -555,7 +555,7 @@ static int test_conc127(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(mysql, NULL, NULL, "./non_exisiting.pem", NULL, NULL);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   diag("Error: %s", mysql_error(mysql));
   FAIL_IF(mysql_errno(mysql) == 0, "Error expected (invalid certificate)");
   mysql_close(mysql);
@@ -576,7 +576,7 @@ static int test_conc50_3(MYSQL *unused __attribute__((unused)))
   FAIL_IF(!mysql, "Can't allocate memory");
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   FAIL_IF(!mysql_errno(mysql), "Error expected, SSL connection required!");
   mysql_close(mysql);
 
@@ -586,7 +586,7 @@ static int test_conc50_3(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(mysql, NULL, NULL, sslca, NULL, NULL);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   diag("Error: %s<", mysql_error(mysql));
   FAIL_IF(mysql_errno(mysql), "No error expected");
   mysql_close(mysql);
@@ -607,7 +607,7 @@ static int test_conc50_4(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(mysql, NULL, sslca, NULL, NULL, NULL);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   FAIL_IF(!mysql_errno(mysql) , "Error expected");
   mysql_close(mysql);
 
@@ -634,7 +634,7 @@ static int verify_ssl_server_cert(MYSQL *unused __attribute__((unused)))
   mysql_options(mysql, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
 
   FAIL_IF(!mysql_errno(mysql), "Expected error");
   diag("Error (expected): %s", mysql_error(mysql));
@@ -656,7 +656,7 @@ static int test_bug62743(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(mysql, "dummykey", NULL, NULL, NULL, NULL);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   diag("Error: %s", mysql_error(mysql));
   FAIL_IF(mysql_errno(mysql) != 2026, "Expected errno 2026");
   mysql_close(mysql);
@@ -667,7 +667,7 @@ static int test_bug62743(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(mysql, sslkey, NULL, NULL, NULL, NULL);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   diag("Error with key: %s", mysql_error(mysql));
   FAIL_IF(mysql_errno(mysql) != 2026, "Expected errno 2026");
   mysql_close(mysql);
@@ -679,7 +679,7 @@ static int test_bug62743(MYSQL *unused __attribute__((unused)))
                        sslcert, NULL, NULL, NULL);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   FAIL_IF(mysql_errno(mysql) != 0, "Expected no error");
   mysql_close(mysql);
 
@@ -689,7 +689,7 @@ static int test_bug62743(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(mysql, sslkey, "blablubb", NULL, NULL, NULL);
 
   mysql_real_connect(mysql, hostname, ssluser, sslpw, schema,
-           port, socketname, 0);
+           ssl_port, socketname, 0);
   diag("Error with cert: %s", mysql_error(mysql));
   FAIL_IF(mysql_errno(mysql) == 0, "Expected error");
   mysql_close(mysql);
@@ -716,7 +716,7 @@ DWORD WINAPI thread_conc102(void)
   mysql_ssl_set(mysql,0, 0, sslca, 0, 0);
 
   if(!mysql_real_connect(mysql, hostname, username, password, schema,
-          port, socketname, 0))
+          ssl_port, socketname, 0))
   {
     diag(">Error: %s", mysql_error(mysql));
     goto end;
@@ -813,12 +813,12 @@ static int test_ssl_fp(MYSQL *unused __attribute__((unused)))
   mysql_options(my, MARIADB_OPT_SSL_FP, bad_cert_finger_print);
 
   FAIL_IF(mysql_real_connect(my, hostname, username, password, schema,
-                             port, socketname, 0), mysql_error(my));
+                             ssl_port, socketname, 0), mysql_error(my));
 
   mysql_options(my, MARIADB_OPT_SSL_FP, ssl_cert_finger_print);
 
   FAIL_IF(!mysql_real_connect(my, hostname, username, password, schema,
-                         port, socketname, 0), mysql_error(my));
+                         ssl_port, socketname, 0), mysql_error(my));
   
   FAIL_IF(check_cipher(my) != 0, "Invalid cipher");
 
@@ -854,7 +854,7 @@ static int test_ssl_fp_list(MYSQL *unused __attribute__((unused)))
   mysql_options(my, MARIADB_OPT_SSL_FP_LIST, CERT_PATH "/server-cert.sha1");
 
   if(!mysql_real_connect(my, hostname, username, password, schema,
-                         port, socketname, 0))
+                         ssl_port, socketname, 0))
   {
     diag("Error: %s", mysql_error(my));
     mysql_close(my);
@@ -880,7 +880,7 @@ static int test_ssl_version(MYSQL *unused __attribute__((unused)))
 
   mysql_ssl_set(my,0, 0, sslca, 0, 0);
   FAIL_IF(!mysql_real_connect(my, hostname, ssluser, sslpw, schema,
-                         port, socketname, 0), mysql_error(my));
+                         ssl_port, socketname, 0), mysql_error(my));
 
   diag("cipher: %s", mysql_get_ssl_cipher(my));
   mariadb_get_infov(my, MARIADB_CONNECTION_TLS_VERSION_ID, &iversion);
@@ -911,7 +911,7 @@ static int test_schannel_cipher(MYSQL *unused __attribute__((unused)))
   mysql_ssl_set(my,0, 0, sslca, 0, 0);
   mysql_options(my, MARIADB_OPT_TLS_CIPHER_STRENGTH, &cipher_strength);
   FAIL_IF(!mysql_real_connect(my, hostname, ssluser, sslpw, schema,
-                         port, socketname, 0), mysql_error(my));
+                         ssl_port, socketname, 0), mysql_error(my));
 
   diag("cipher: %s", mysql_get_ssl_cipher(my));
 
@@ -969,7 +969,7 @@ static int test_cipher_mapping(MYSQL *unused __attribute__((unused)))
     
     mysql->options.use_ssl= 1;
     FAIL_IF(!mysql_real_connect(mysql, hostname, username, password, schema,
-                         port, socketname, 0), mysql_error(mysql));
+                         ssl_port, socketname, 0), mysql_error(mysql));
     if (!(cipher= mysql_get_ssl_cipher(mysql)) ||
         strcmp(ciphers[i], cipher) != 0)
     {
@@ -1038,14 +1038,14 @@ static int test_openssl_1(MYSQL *mysql)
   my= mysql_init(NULL);
   mysql_ssl_set(my, NULL, NULL, NULL, NULL, "AES128-SHA");
   FAIL_IF(!mysql_real_connect(my, hostname, "ssluser1", NULL, schema,
-                         port, socketname, 0), mysql_error(my));
+                         ssl_port, socketname, 0), mysql_error(my));
   FAIL_IF(!mysql_get_ssl_cipher(my), "No TLS connection");
   mysql_close(my);
 
   my= mysql_init(NULL);
   mysql_options(my, MYSQL_OPT_SSL_ENFORCE, &val);
   FAIL_IF(!mysql_real_connect(my, hostname, "ssluser1", NULL, schema,
-                         port, socketname, 0), mysql_error(my));
+                         ssl_port, socketname, 0), mysql_error(my));
   FAIL_IF(!mysql_get_ssl_cipher(my), "No TLS connection");
   mysql_close(my);
 
@@ -1059,7 +1059,7 @@ static int test_openssl_1(MYSQL *mysql)
   my= mysql_init(NULL);
   mysql_options(my, MYSQL_OPT_SSL_ENFORCE, &val);
   mysql_real_connect(my, hostname, "ssluser2", NULL, schema,
-                         port, socketname, 0);
+                         ssl_port, socketname, 0);
   if (!mysql_error(my) &&
        strcmp(mysql_get_ssl_cipher(my), "AES256-SHA"))
   {
@@ -1075,7 +1075,7 @@ static int test_openssl_1(MYSQL *mysql)
     my= mysql_init(NULL);
     mysql_ssl_set(my, NULL, NULL, NULL, NULL, "AES256-SHA");
     FAIL_IF(!mysql_real_connect(my, hostname, "ssluser2", NULL, schema,
-                           port, socketname, 0), mysql_error(my));
+                           ssl_port, socketname, 0), mysql_error(my));
     FAIL_IF(strcmp("AES256-SHA", mysql_get_ssl_cipher(my)) != 0, "expected cipher AES256-SHA");
     mysql_close(my);
   }
@@ -1085,7 +1085,7 @@ static int test_openssl_1(MYSQL *mysql)
   my= mysql_init(NULL);
   mysql_ssl_set(my, NULL, NULL, NULL, NULL, "AES128-SHA");
   FAIL_IF(mysql_real_connect(my, hostname, "ssluser2", NULL, schema,
-                         port, socketname, 0), "Error expected");
+                         ssl_port, socketname, 0), "Error expected");
   mysql_close(my);
 
 
@@ -1100,7 +1100,7 @@ static int test_openssl_1(MYSQL *mysql)
     my= mysql_init(NULL);
     mysql_ssl_set(my, NULL, NULL, NULL, NULL, "AES256-SHA");
     FAIL_IF(mysql_real_connect(my, hostname, "ssluser3", NULL, schema,
-                               port, socketname, 0), "Error expected");
+                               ssl_port, socketname, 0), "Error expected");
     mysql_close(my);
 
     /* ssluser3 connect with cipher and certs */
@@ -1111,7 +1111,7 @@ static int test_openssl_1(MYSQL *mysql)
                   NULL, 
                   "AES256-SHA");
     FAIL_IF(!mysql_real_connect(my, hostname, "ssluser3", NULL, schema,
-                           port, socketname, 0), mysql_error(my));
+                           ssl_port, socketname, 0), mysql_error(my));
 
     mysql_close(my);
 
@@ -1124,7 +1124,7 @@ static int test_openssl_1(MYSQL *mysql)
     my= mysql_init(NULL);
     mysql_ssl_set(my, NULL, NULL, NULL, NULL, "AES256-SHA");
     FAIL_IF(mysql_real_connect(my, hostname, "ssluser4", NULL, schema,
-                           port, socketname, 0), "Error expected");
+                           ssl_port, socketname, 0), "Error expected");
     mysql_close(my);
 
     /* ssluser4 connect with cipher and certs */
@@ -1135,7 +1135,7 @@ static int test_openssl_1(MYSQL *mysql)
                   NULL,
                   "AES256-SHA");
     FAIL_IF(!mysql_real_connect(my, hostname, "ssluser4", NULL, schema,
-                           port, socketname, 0), mysql_error(my));
+                           ssl_port, socketname, 0), mysql_error(my));
     mysql_close(my);
   }
   diag("drop users");
@@ -1163,7 +1163,7 @@ static int test_ssl_timeout(MYSQL *unused __attribute__((unused)))
   mysql_options(mysql, MYSQL_OPT_READ_TIMEOUT, &read_timeout);
   mysql->options.use_ssl= 1;
   FAIL_IF(!mysql_real_connect(mysql, hostname, username, password, schema,
-                         port, socketname, 0), mysql_error(mysql));
+                         ssl_port, socketname, 0), mysql_error(mysql));
   diag("cipher: %s\n", mysql_get_ssl_cipher(mysql));
   rc= mysql_query(mysql, "SELECT SLEEP(600)");
   if (!rc)
@@ -1200,7 +1200,7 @@ static int test_conc286(MYSQL *unused __attribute__((unused)))
   mysql_options(my, MARIADB_OPT_SSL_FP, ssl_cert_finger_print);
 
   FAIL_IF(!mysql_real_connect(my, hostname, username, password, schema,
-                         port, socketname, 0), mysql_error(my));
+                         ssl_port, socketname, 0), mysql_error(my));
   
   FAIL_IF(check_cipher(my) != 0, "Invalid cipher");
 
@@ -1276,7 +1276,7 @@ static int test_mdev14101(MYSQL *my __attribute__((unused)))
     mysql_options(mysql, MYSQL_OPT_SSL_ENFORCE, &val);
     mysql_options(mysql, MARIADB_OPT_TLS_VERSION, combinations[i].opt_tls_version);
     FAIL_IF(!mysql_real_connect(mysql, hostname, username, password, schema,
-                         port, socketname, 0), mysql_error(mysql));
+                         ssl_port, socketname, 0), mysql_error(mysql));
     mariadb_get_infov(mysql, MARIADB_CONNECTION_TLS_VERSION, &tls_version);
     diag("options: %s", combinations[i].opt_tls_version);
     diag("protocol: %s expected: %s", tls_version, combinations[i].expected);
@@ -1296,7 +1296,7 @@ static int test_conc386(MYSQL *mysql)
                 NULL,
                 NULL);
   FAIL_IF(!mysql_real_connect(mysql, hostname, username, password, schema,
-                         port, socketname, 0), mysql_error(mysql));
+                         ssl_port, socketname, 0), mysql_error(mysql));
   FAIL_IF(check_cipher(mysql) != 0, "Invalid cipher");
   mysql_close(mysql);
   return OK;
@@ -1316,7 +1316,7 @@ static int test_ssl_verify(MYSQL *my __attribute__((unused)))
   mysql_options(mysql, MYSQL_OPT_SSL_ENFORCE, &enforce);
   mysql_options(mysql, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify);
   FAIL_IF(mysql_real_connect(mysql, hostname, username, password, schema,
-                         port, socketname, 0), "Error expected");
+                         ssl_port, socketname, 0), "Error expected");
   diag("error expected: %s\n", mysql_error(mysql));
   mysql_close(mysql);
 
@@ -1338,13 +1338,13 @@ static int test_ssl_verify(MYSQL *my __attribute__((unused)))
   mysql_ssl_set(mysql,0, 0, sslca, 0, 0);
   mysql_options(mysql, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify);
   FAIL_IF(!mysql_real_connect(mysql, hostname, username, password, schema,
-                         port, socketname, 0), mysql_error(mysql));
+                         ssl_port, socketname, 0), mysql_error(mysql));
   mysql_close(mysql);
 
   mysql= mysql_init(NULL);
   mysql_options(mysql, MYSQL_OPT_SSL_ENFORCE, &enforce);
   FAIL_IF(!mysql_real_connect(mysql, hostname, username, password, schema,
-                         port, socketname, 0), mysql_error(mysql));
+                         ssl_port, socketname, 0), mysql_error(mysql));
 
   diag("cipher: %s", mysql_get_ssl_cipher(mysql));
   mysql_close(mysql);


### PR DESCRIPTION
This permit testing with 2.5.3 maxscale version in travis.

new testing variables :
* MYSQL_TEST_SSL_PORT: permit to have a different port to test SSL (maxscale only permit non SSL or SSL required)
* MAXSCALE_TEST_DISABLE: indicate to disable some tests for maxscale. Not setting this enviroment variable, whole test suite will run.
maxscale test env is using port 4006 (non SSL), and 4009 (SSL mandatory).