### PR TITLE
Fix race condition on global max_allowed_packet and net_buffer_length

### DIFF
--- a/include/mariadb_com.h
+++ b/include/mariadb_com.h
@@ -382,8 +382,17 @@ enum enum_field_types { MYSQL_TYPE_DECIMAL, MYSQL_TYPE_TINY,
 #define FIELD_TYPE_GEOMETRY MYSQL_TYPE_GEOMETRY
 #define FIELD_TYPE_BIT MYSQL_TYPE_BIT
 
-extern unsigned long max_allowed_packet;
-extern unsigned long net_buffer_length;
+#if defined(__cplusplus) && defined(__GNUC__) && !defined(__clang__)
+extern "C++" {
+    #include <atomic>
+}
+
+#define _Atomic(T) std::atomic<T>
+
+#endif
+
+extern _Atomic(unsigned long) max_allowed_packet;
+extern _Atomic(unsigned long) net_buffer_length;
 
 #define net_new_transaction(net) ((net)->pkt_nr=0)
 

--- a/libmariadb/ma_net.c
+++ b/libmariadb/ma_net.c
@@ -47,10 +47,10 @@
 #undef net_buffer_length
 
 #undef max_allowed_packet
-ulong max_allowed_packet=1024L * 1024L * 1024L;
+_Atomic(ulong) max_allowed_packet=1024L * 1024L * 1024L;
 ulong net_read_timeout=  NET_READ_TIMEOUT;
 ulong net_write_timeout= NET_WRITE_TIMEOUT;
-ulong net_buffer_length= 8192;	/* Default length. Enlarged if necessary */
+_Atomic(ulong) net_buffer_length= 8192;	/* Default length. Enlarged if necessary */
 
 #if !defined(_WIN32) && !defined(MSDOS)
 #include <sys/socket.h>

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -85,8 +85,8 @@
 
 #undef max_allowed_packet
 #undef net_buffer_length
-extern ulong max_allowed_packet; /* net.c */
-extern ulong net_buffer_length;  /* net.c */
+extern _Atomic(ulong) max_allowed_packet; /* net.c */
+extern _Atomic(ulong) net_buffer_length;  /* net.c */
 
 static MYSQL_PARAMETERS mariadb_internal_parameters= {&max_allowed_packet, &net_buffer_length, 0};
 static my_bool mysql_client_init=0;


### PR DESCRIPTION
Hello! In [ClickHouse DBMS](https://github.com/ClickHouse/ClickHouse) we use `mariadb-connector-c` for interactions with MySQL. We have a lot of tests for this functionality which runs with different [sanitizers](https://github.com/google/sanitizers). Recently thread sanitizer detected race condition in `mariadb-connector-c`: [link](https://gist.github.com/alesapin/1fa65d66dd24be123abba86c25410be5). Seems like this race caused by changes in global variables from different threads which cannot be controlled by the library user code.

Fix in this PR is the most straightforward way to avoid race condition. 

Thanks for the great library.