### PR TITLE
MDEV-22189: Change error messages inside code to have mariadb instead of

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,16 @@ branches:
   - 3.1
 environment:
   matrix:
-    - DB: '10.2.34'
+    - DB: '10.2.37'
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_PARAM: 'Visual Studio 15 2017 Win64'
-    - DB: '10.3.25'
+    - DB: '10.3.28'
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_PARAM: 'Visual Studio 15 2017 Win64'
-    - DB: '10.4.15'
+    - DB: '10.4.18'
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_PARAM: 'Visual Studio 15 2017 Win64'
-    - DB: '10.5.6'
+    - DB: '10.5.9'
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_PARAM: 'Visual Studio 15 2017 Win64'
 

--- a/libmariadb/ma_charset.c
+++ b/libmariadb/ma_charset.c
@@ -536,7 +536,7 @@ static unsigned int check_mb_gb18030_valid(const char * start, const char * end)
 /* }}} */
 
 /*
-  The server compiles sometimes the full utf-8 (the mb4) as utf8m4, and the old as utf8,
+  The server compiles sometimes the full utf-8 (the mb4) as utf8mb4, and the old as utf8,
   for BC reasons. Sometimes, utf8mb4 is just utf8 but the old charsets are utf8mb3.
   Change easily now, with a macro, could be made compilastion dependable.
 */

--- a/libmariadb/ma_default.c
+++ b/libmariadb/ma_default.c
@@ -124,13 +124,11 @@ char **get_default_configuration_dirs()
     goto error;
 #endif
 #endif
-/* This differs from https://mariadb.com/kb/en/mariadb/configuring-mariadb-with-mycnf/ where MYSQL_HOME is not specified for Windows */
-  if ((env= getenv("MYSQL_HOME")) &&
-      add_cfg_dir(configuration_dirs, env))
-    goto error;
-  /* CONC-449: Check $MARIADB_HOME/my.cnf in addition to $MYSQL_HOME/my.cnf */
-  if ((env= getenv("MARIADB_HOME")) &&
-      add_cfg_dir(configuration_dirs, env))
+  /* CONC-537: Read configuration files from MYSQL_HOME directory only if
+     MARIADB_HOME was not set */
+  if (!(env= getenv("MARIADB_HOME")))
+    env= getenv("MYSQL_HOME");
+  if (env && add_cfg_dir(configuration_dirs, env))
     goto error;
 end:
   return configuration_dirs;

--- a/libmariadb/ma_errmsg.c
+++ b/libmariadb/ma_errmsg.c
@@ -15,7 +15,7 @@
    Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
    MA 02111-1301, USA */
 
-/* Error messages for MySQL clients */
+/* Error messages for clients */
 /* error messages for the demon is in share/language/errmsg.sys */
 
 #include <ma_global.h>
@@ -25,77 +25,22 @@
 
 const char *SQLSTATE_UNKNOWN= "HY000";
 
-#ifdef GERMAN
 const char *client_errors[]=
 {
-  "Unbekannter MySQL Fehler",
-  "Kann UNIX-Socket nicht anlegen (%d)",
-  "Keine Verbindung zu lokalem MySQL Server, socket: '%-.64s' (%d)",
-  "Keine Verbindung zu MySQL Server auf %-.64s (%d)",
-  "Kann TCP/IP-Socket nicht anlegen (%d)",
-  "Unbekannter MySQL Server Host (%-.64s) (%d)",
-  "MySQL Server nicht vorhanden",
-  "Protokolle ungleich. Server Version = % d Client Version = %d",
-  "MySQL client got out of memory",
-  "Wrong host info",
-  "Localhost via UNIX socket",
-  "%-.64s via TCP/IP",
-  "Error in server handshake",
-  "Lost connection to MySQL server during query",
-  "Commands out of sync; you can't run this command now",
-  "Verbindung ueber Named Pipe; Host: %-.64s",
-  "Kann nicht auf Named Pipe warten. Host: %-.64s  pipe: %-.32s (%lu)",
-  "Kann Named Pipe nicht oeffnen. Host: %-.64s  pipe: %-.32s (%lu)",
-  "Kann den Status der Named Pipe nicht setzen.  Host: %-.64s  pipe: %-.32s (%lu)",
-  "Can't initialize character set %-.64s (path: %-.64s)",
-  "Got packet bigger than 'max_allowed_packet'"
-};
-
-/* Start of code added by Roberto M. Serqueira - martinsc@uol.com.br - 05.24.2001 */
-
-#elif defined PORTUGUESE
-const char *client_errors[]=
-{
-  "Erro desconhecido do MySQL",
-  "N�o pode criar 'UNIX socket' (%d)",
-  "N�o pode se conectar ao servidor MySQL local atrav�s do 'socket' '%-.64s' (%d)", 
-  "N�o pode se conectar ao servidor MySQL em '%-.64s' (%d)",
-  "N�o pode criar 'socket TCP/IP' (%d)",
-  "'Host' servidor MySQL '%-.64s' (%d) desconhecido", 
-  "Servidor MySQL desapareceu",
-  "Incompatibilidade de protocolos. Vers�o do Servidor: %d - Vers�o do Cliente: %d",
-  "Cliente do MySQL com falta de mem�ria",
-  "Informa��o inv�lida de 'host'",
-  "Localhost via 'UNIX socket'",
-  "%-.64s via 'TCP/IP'",
-  "Erro na negocia��o de acesso ao servidor",
-  "Conex�o perdida com servidor MySQL durante 'query'",
-  "Comandos fora de sincronismo. Voc� n�o pode executar este comando agora",
-  "%-.64s via 'named pipe'",
-  "N�o pode esperar pelo 'named pipe' para o 'host' %-.64s - 'pipe' %-.32s (%lu)",
-  "N�o pode abrir 'named pipe' para o 'host' %-.64s - 'pipe' %-.32s (%lu)",
-  "N�o pode estabelecer o estado do 'named pipe' para o 'host' %-.64s - 'pipe' %-.32s (%lu)",
-  "N�o pode inicializar conjunto de caracteres %-.64s (caminho %-.64s)",
-  "Obteve pacote maior do que 'max_allowed_packet'"
-};
-
-#else /* ENGLISH */
-const char *client_errors[]=
-{
-/* 2000 */  "Unknown MySQL error",
+/* 2000 */  "Unknown error",
 /* 2001 */  "Can't create UNIX socket (%d)",
-/* 2002 */  "Can't connect to local MySQL server through socket '%-.64s' (%d)",
-/* 2003 */  "Can't connect to MySQL server on '%-.64s' (%d)",
+/* 2002 */  "Can't connect to local server through socket '%-.64s' (%d)",
+/* 2003 */  "Can't connect to server on '%-.64s' (%d)",
 /* 2004 */  "Can't create TCP/IP socket (%d)",
-/* 2005 */  "Unknown MySQL server host '%-.100s' (%d)",
-/* 2006 */  "MySQL server has gone away",
+/* 2005 */  "Unknown server host '%-.100s' (%d)",
+/* 2006 */  "Server has gone away",
 /* 2007 */  "Protocol mismatch. Server Version = %d Client Version = %d",
-/* 2008 */  "MySQL client run out of memory",
+/* 2008 */  "Client run out of memory",
 /* 2009 */  "Wrong host info",
 /* 2010 */  "Localhost via UNIX socket",
 /* 2011 */  "%-.64s via TCP/IP",
 /* 2012 */  "Error in server handshake",
-/* 2013 */  "Lost connection to MySQL server during query",
+/* 2013 */  "Lost connection to server during query",
 /* 2014 */  "Commands out of sync; you can't run this command now",
 /* 2015 */  "%-.64s via named pipe",
 /* 2016 */  "Can't wait for named pipe to host: %-.64s  pipe: %-.32s (%lu)",
@@ -109,7 +54,7 @@ const char *client_errors[]=
 /* 2024 */  "",
 /* 2025 */  "",
 /* 2026 */  "SSL connection error: %-.100s",
-/* 2027 */  "received malformed packet",
+/* 2027 */  "Received malformed packet",
 /* 2028 */  "",
 /* 2029 */  "",
 /* 2030 */  "Statement is not prepared",
@@ -137,7 +82,7 @@ const char *client_errors[]=
 /* 2052 */  "Prepared statement contains no metadata",
 /* 2053 */  "",
 /* 2054 */  "This feature is not implemented or disabled",
-/* 2055 */  "Lost connection to MySQL server at '%s', system error: %d",
+/* 2055 */  "Lost connection to server at '%s', system error: %d",
 /* 2056 */  "Server closed statement due to a prior %s function call",
 /* 2057 */  "The number of parameters in bound buffers differs from number of columns in resultset",
 /* 2059 */  "Can't connect twice. Already connected",
@@ -146,7 +91,6 @@ const char *client_errors[]=
 /* 2060 */  "Plugin doesn't support this function",
             ""
 };
-#endif
 
 const char *mariadb_client_errors[] =
 {

--- a/libmariadb/mariadb_rpl.c
+++ b/libmariadb/mariadb_rpl.c
@@ -235,7 +235,7 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
       ev+= db_len + 1; /* zero terminated */
 
       /* calculate statement size: buffer + buffer_size - current_ofs (ev) - crc_size */
-      len= (size_t)(rpl->buffer + rpl->buffer_size - ev - 4);
+      len= (size_t)(rpl->buffer + rpl->buffer_size - ev - (rpl->use_checksum ? 4 : 0));
       if (rpl_alloc_string(rpl_event, &rpl_event->event.query.statement, ev, len))
         goto mem_error;
       break;
@@ -302,7 +302,7 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
       rpl_event->event.encryption.nonce= (char *)ev;
       break;
     case ANNOTATE_ROWS_EVENT:
-      len= (uint32)(rpl->buffer + rpl->buffer_size - (unsigned char *)ev - 4);
+      len= (uint32)(rpl->buffer + rpl->buffer_size - (unsigned char *)ev - (rpl->use_checksum ? 4 : 0));
       if (rpl_alloc_string(rpl_event, &rpl_event->event.annotate_rows.statement, ev, len))
         goto mem_error;
       break;


### PR DESCRIPTION
mysql

This patch is made as a part of MDEV-22189 which required changing error
messages for client.