### PR TITLE
MDEV-8334: Rename utf8 to utf8mb3

### DIFF
--- a/libmariadb/ma_charset.c
+++ b/libmariadb/ma_charset.c
@@ -542,7 +542,7 @@ static unsigned int check_mb_gb18030_valid(const char * start, const char * end)
 */
 
 #define UTF8_MB4 "utf8mb4"
-#define UTF8_MB3 "utf8"
+#define UTF8_MB3 "utf8mb3"
 
 /* {{{ mysql_charsets */
 const MARIADB_CHARSET_INFO mariadb_compiled_charsets[] =
@@ -957,6 +957,8 @@ MARIADB_CHARSET_INFO * mysql_find_charset_name(const char *name)
   MARIADB_CHARSET_INFO *c = (MARIADB_CHARSET_INFO *)mariadb_compiled_charsets;
   const char *csname;
 
+  if (!strcasecmp("utf8",name))
+    name= "utf8mb3";
   if (!strcasecmp(name, MADB_AUTODETECT_CHARSET_NAME))
     csname= madb_get_os_character_set();
   else

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -3796,6 +3796,8 @@ int STDCALL mysql_set_character_set(MYSQL *mysql, const char *csname)
 
   if (!csname)
     goto error;
+  if (!strcasecmp("utf8",csname))
+    csname= "utf8mb4";
 
   if ((cs= mysql_find_charset_name(csname)))
   {

--- a/unittest/libmariadb/basic-t.c
+++ b/unittest/libmariadb/basic-t.c
@@ -121,7 +121,7 @@ static int test_conc71(MYSQL *my)
   mysql= mysql_init(NULL);
 
 
-  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8");
+  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8mb3");
   mysql_options(mysql, MYSQL_OPT_COMPRESS, 0);
   mysql_options(mysql, MYSQL_INIT_COMMAND, "/*!40101 SET SQL_MODE='' */");
   mysql_options(mysql, MYSQL_INIT_COMMAND, "/*!40101 set @@session.wait_timeout=28800 */");
@@ -310,7 +310,7 @@ static int use_utf8(MYSQL *my)
 
   while ((row= mysql_fetch_row(res)) != NULL)
   {
-    FAIL_IF(strcmp(row[0], "utf8"), "wrong character set");
+    FAIL_IF(strcmp(row[0], "utf8mb3"), "wrong character set");
   }
   FAIL_IF(mysql_errno(my), mysql_error(my));
   mysql_free_result(res);

--- a/unittest/libmariadb/charset.c
+++ b/unittest/libmariadb/charset.c
@@ -78,7 +78,7 @@ int test_client_character_set(MYSQL *mysql)
 
   mysql_get_character_set_info(mysql, &cs);
 
-  FAIL_IF(strcmp(cs.csname, "utf8") || strcmp(cs.name, "utf8_general_ci"), "Character set != UTF8");
+  FAIL_IF(strcmp(cs.csname, "utf8mb3") || strcmp(cs.name, "utf8mb3_general_ci"), "Character set != UTF8MB3");
   FAIL_IF(mysql_set_character_set(mysql, csdefault), mysql_error(mysql));
 
   return OK;
@@ -553,7 +553,7 @@ static int test_bug30472(MYSQL *mysql)
 
   /* Switch client character set. */
 
-  FAIL_IF(mysql_set_character_set(mysql, "utf8"), "Setting cs to utf8 failed");
+  FAIL_IF(mysql_set_character_set(mysql, "utf8mb3"), "Setting cs to utf8mb3 failed");
 
   /* Retrieve character set information. */
 
@@ -569,10 +569,10 @@ static int test_bug30472(MYSQL *mysql)
       2) new character set is different from the original one.
   */
 
-  FAIL_UNLESS(strcmp(character_set_name_2, "utf8") == 0, "cs_name != utf8");
-  FAIL_UNLESS(strcmp(character_set_client_2, "utf8") == 0, "cs_client != utf8");
-  FAIL_UNLESS(strcmp(character_set_results_2, "utf8") == 0, "cs_result != ut8");
-  FAIL_UNLESS(strcmp(collation_connnection_2, "utf8_general_ci") == 0, "collation != utf8_general_ci");
+  FAIL_UNLESS(strcmp(character_set_name_2, "utf8mb3") == 0, "cs_name != utf8mb3");
+  FAIL_UNLESS(strcmp(character_set_client_2, "utf8mb3") == 0, "cs_client != utf8mb3");
+  FAIL_UNLESS(strcmp(character_set_results_2, "utf8mb3") == 0, "cs_result != ut8mb3");
+  FAIL_UNLESS(strcmp(collation_connnection_2, "utf8mb3_general_ci") == 0, "collation != utf8mb3_general_ci");
 
   diag("%s %s", character_set_name_1, character_set_name_2);
   FAIL_UNLESS(strcmp(character_set_name_1, character_set_name_2) != 0, "cs_name1 = cs_name2");
@@ -603,7 +603,7 @@ static int test_bug30472(MYSQL *mysql)
 
   /* Change connection-default character set in the client. */
 
-  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8");
+  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8mb3");
 
   /*
     Call mysql_change_user() in order to check that new connection will
@@ -623,10 +623,10 @@ static int test_bug30472(MYSQL *mysql)
 
   /* Check that we have UTF8 on the server and on the client. */
 
-  FAIL_UNLESS(strcmp(character_set_name_4, "utf8") == 0, "cs_name != utf8");
-  FAIL_UNLESS(strcmp(character_set_client_4, "utf8") == 0, "cs_client != utf8");
-  FAIL_UNLESS(strcmp(character_set_results_4, "utf8") == 0, "cs_result != utf8");
-  FAIL_UNLESS(strcmp(collation_connnection_4, "utf8_general_ci") == 0, "collation_connection != utf8_general_ci");
+  FAIL_UNLESS(strcmp(character_set_name_4, "utf8mb3") == 0, "cs_name != utf8mb3");
+  FAIL_UNLESS(strcmp(character_set_client_4, "utf8mb3") == 0, "cs_client != utf8mb3");
+  FAIL_UNLESS(strcmp(character_set_results_4, "utf8mb3") == 0, "cs_result != utf8mb3");
+  FAIL_UNLESS(strcmp(collation_connnection_4, "utf8mb3_general_ci") == 0, "collation_connection != utf8mb3_general_ci");
 
   /* That's it. Cleanup. */
 

--- a/unittest/libmariadb/connection.c
+++ b/unittest/libmariadb/connection.c
@@ -640,13 +640,13 @@ int test_conc21(MYSQL *mysql)
 int test_conc26(MYSQL *unused __attribute__((unused)))
 {
   MYSQL *mysql= mysql_init(NULL);
-  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8");
+  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8mb3");
 
   FAIL_IF(my_test_connect(mysql, hostname, "notexistinguser", "password", schema, port, NULL, CLIENT_REMEMBER_OPTIONS), 
           "Error expected");
 
-  FAIL_IF(!mysql->options.charset_name || strcmp(mysql->options.charset_name, "utf8") != 0, 
-          "expected charsetname=utf8");
+  FAIL_IF(!mysql->options.charset_name || strcmp(mysql->options.charset_name, "utf8mb3") != 0, 
+          "expected charsetname=utf8mb3");
   mysql_close(mysql);
 
   mysql= mysql_init(NULL);
@@ -981,7 +981,7 @@ static int test_sess_track_db(MYSQL *mysql)
       printf("# SESSION_TRACK_VARIABLES: %*.*s\n", (int)len, (int)len, data);
     } while (!mysql_session_track_get_next(mysql, SESSION_TRACK_SYSTEM_VARIABLES, &data, &len));
     diag("charset: %s", mysql->charset->csname);
-    FAIL_IF(strcmp(mysql->charset->csname, "utf8"), "Expected charset 'utf8'");
+    FAIL_IF(strcmp(mysql->charset->csname, "utf8mb3"), "Expected charset 'utf8mb3'");
 
     rc= mysql_query(mysql, "SET NAMES latin1");
     check_mysql_rc(rc, mysql);


### PR DESCRIPTION
This patch is made as a part of MDEV-8334 to fix failing test in unit and
main test suite so that utf8mb3 characterset is recognized. Failing tests:
main.mysql_client_test
main.mysql_client_test_comp
unit.conc_basic-t
unit.conc_charset
unit.conc_connection