### PR TITLE
bb-3.2-rucha-mdev-8334

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,16 @@ branches:
   - 3.1
 environment:
   matrix:
-    - DB: '10.2.34'
+    - DB: '10.2.37'
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_PARAM: 'Visual Studio 15 2017 Win64'
-    - DB: '10.3.25'
+    - DB: '10.3.28'
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_PARAM: 'Visual Studio 15 2017 Win64'
-    - DB: '10.4.15'
+    - DB: '10.4.18'
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_PARAM: 'Visual Studio 15 2017 Win64'
-    - DB: '10.5.6'
+    - DB: '10.5.9'
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_PARAM: 'Visual Studio 15 2017 Win64'
 

--- a/libmariadb/ma_charset.c
+++ b/libmariadb/ma_charset.c
@@ -536,7 +536,7 @@ static unsigned int check_mb_gb18030_valid(const char * start, const char * end)
 /* }}} */
 
 /*
-  The server compiles sometimes the full utf-8 (the mb4) as utf8m4, and the old as utf8,
+  The server compiles sometimes the full utf-8 (the mb4) as utf8mb4, and the old as utf8,
   for BC reasons. Sometimes, utf8mb4 is just utf8 but the old charsets are utf8mb3.
   Change easily now, with a macro, could be made compilastion dependable.
 */

--- a/libmariadb/ma_charset.c
+++ b/libmariadb/ma_charset.c
@@ -542,7 +542,7 @@ static unsigned int check_mb_gb18030_valid(const char * start, const char * end)
 */
 
 #define UTF8_MB4 "utf8mb4"
-#define UTF8_MB3 "utf8"
+#define UTF8_MB3 "utf8mb3"
 
 /* {{{ mysql_charsets */
 const MARIADB_CHARSET_INFO mariadb_compiled_charsets[] =
@@ -961,6 +961,9 @@ MARIADB_CHARSET_INFO * mysql_find_charset_name(const char *name)
     csname= madb_get_os_character_set();
   else
     csname= (char *)name;
+
+  if (!strcasecmp("utf8",csname))
+    csname= "utf8mb3";
 
   do {
     if (!strcasecmp(c->csname, csname)) {

--- a/libmariadb/ma_default.c
+++ b/libmariadb/ma_default.c
@@ -124,13 +124,11 @@ char **get_default_configuration_dirs()
     goto error;
 #endif
 #endif
-/* This differs from https://mariadb.com/kb/en/mariadb/configuring-mariadb-with-mycnf/ where MYSQL_HOME is not specified for Windows */
-  if ((env= getenv("MYSQL_HOME")) &&
-      add_cfg_dir(configuration_dirs, env))
-    goto error;
-  /* CONC-449: Check $MARIADB_HOME/my.cnf in addition to $MYSQL_HOME/my.cnf */
-  if ((env= getenv("MARIADB_HOME")) &&
-      add_cfg_dir(configuration_dirs, env))
+  /* CONC-537: Read configuration files from MYSQL_HOME directory only if
+     MARIADB_HOME was not set */
+  if (!(env= getenv("MARIADB_HOME")))
+    env= getenv("MYSQL_HOME");
+  if (env && add_cfg_dir(configuration_dirs, env))
     goto error;
 end:
   return configuration_dirs;

--- a/libmariadb/mariadb_rpl.c
+++ b/libmariadb/mariadb_rpl.c
@@ -235,7 +235,7 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
       ev+= db_len + 1; /* zero terminated */
 
       /* calculate statement size: buffer + buffer_size - current_ofs (ev) - crc_size */
-      len= (size_t)(rpl->buffer + rpl->buffer_size - ev - 4);
+      len= (size_t)(rpl->buffer + rpl->buffer_size - ev - (rpl->use_checksum ? 4 : 0));
       if (rpl_alloc_string(rpl_event, &rpl_event->event.query.statement, ev, len))
         goto mem_error;
       break;
@@ -302,7 +302,7 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
       rpl_event->event.encryption.nonce= (char *)ev;
       break;
     case ANNOTATE_ROWS_EVENT:
-      len= (uint32)(rpl->buffer + rpl->buffer_size - (unsigned char *)ev - 4);
+      len= (uint32)(rpl->buffer + rpl->buffer_size - (unsigned char *)ev - (rpl->use_checksum ? 4 : 0));
       if (rpl_alloc_string(rpl_event, &rpl_event->event.annotate_rows.statement, ev, len))
         goto mem_error;
       break;

--- a/unittest/libmariadb/basic-t.c
+++ b/unittest/libmariadb/basic-t.c
@@ -310,7 +310,8 @@ static int use_utf8(MYSQL *my)
 
   while ((row= mysql_fetch_row(res)) != NULL)
   {
-    FAIL_IF(strcmp(row[0], "utf8"), "wrong character set");
+    FAIL_IF(strncmp(row[0], "utf8", 4),
+                   "wrong character set");
   }
   FAIL_IF(mysql_errno(my), mysql_error(my));
   mysql_free_result(res);

--- a/unittest/libmariadb/charset.c
+++ b/unittest/libmariadb/charset.c
@@ -71,14 +71,16 @@ int bug_8378(MYSQL *mysql) {
 int test_client_character_set(MYSQL *mysql)
 {
   MY_CHARSET_INFO cs;
-  char *csname= (char*) "utf8";
+  char *csname= (char*) "latin2";
   char *csdefault= (char*)mysql_character_set_name(mysql);
+
 
   FAIL_IF(mysql_set_character_set(mysql, csname), mysql_error(mysql));
 
   mysql_get_character_set_info(mysql, &cs);
 
-  FAIL_IF(strcmp(cs.csname, "utf8") || strcmp(cs.name, "utf8_general_ci"), "Character set != UTF8");
+  FAIL_IF(strcmp(cs.csname, "latin2") || strcmp(cs.name, "latin2_general_ci"),
+          "Character set != latin2");
   FAIL_IF(mysql_set_character_set(mysql, csdefault), mysql_error(mysql));
 
   return OK;
@@ -553,7 +555,8 @@ static int test_bug30472(MYSQL *mysql)
 
   /* Switch client character set. */
 
-  FAIL_IF(mysql_set_character_set(mysql, "utf8"), "Setting cs to utf8 failed");
+  FAIL_IF(mysql_set_character_set(mysql, "ascii"),
+          "Setting cs to ascii failed");
 
   /* Retrieve character set information. */
 
@@ -569,10 +572,11 @@ static int test_bug30472(MYSQL *mysql)
       2) new character set is different from the original one.
   */
 
-  FAIL_UNLESS(strcmp(character_set_name_2, "utf8") == 0, "cs_name != utf8");
-  FAIL_UNLESS(strcmp(character_set_client_2, "utf8") == 0, "cs_client != utf8");
-  FAIL_UNLESS(strcmp(character_set_results_2, "utf8") == 0, "cs_result != ut8");
-  FAIL_UNLESS(strcmp(collation_connnection_2, "utf8_general_ci") == 0, "collation != utf8_general_ci");
+  FAIL_UNLESS(strcmp(character_set_name_2, "ascii") == 0, "cs_name != ascii");
+  FAIL_UNLESS(strcmp(character_set_client_2, "ascii") == 0, "cs_client != ascii");
+  FAIL_UNLESS(strcmp(character_set_results_2, "ascii") == 0, "cs_result != ascii");
+  FAIL_UNLESS(strcmp(collation_connnection_2, "ascii_general_ci") == 0,
+              "collation != ascii_general_ci");
 
   diag("%s %s", character_set_name_1, character_set_name_2);
   FAIL_UNLESS(strcmp(character_set_name_1, character_set_name_2) != 0, "cs_name1 = cs_name2");
@@ -603,7 +607,7 @@ static int test_bug30472(MYSQL *mysql)
 
   /* Change connection-default character set in the client. */
 
-  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8");
+  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "latin2");
 
   /*
     Call mysql_change_user() in order to check that new connection will
@@ -623,10 +627,11 @@ static int test_bug30472(MYSQL *mysql)
 
   /* Check that we have UTF8 on the server and on the client. */
 
-  FAIL_UNLESS(strcmp(character_set_name_4, "utf8") == 0, "cs_name != utf8");
-  FAIL_UNLESS(strcmp(character_set_client_4, "utf8") == 0, "cs_client != utf8");
-  FAIL_UNLESS(strcmp(character_set_results_4, "utf8") == 0, "cs_result != utf8");
-  FAIL_UNLESS(strcmp(collation_connnection_4, "utf8_general_ci") == 0, "collation_connection != utf8_general_ci");
+  FAIL_UNLESS(strcmp(character_set_name_4, "latin2") == 0, "cs_name != latin2");
+  FAIL_UNLESS(strcmp(character_set_client_4, "latin2") == 0, "cs_client != latin2");
+  FAIL_UNLESS(strcmp(character_set_results_4, "latin2") == 0, "cs_result != latin2");
+  FAIL_UNLESS(strcmp(collation_connnection_4, "latin2_general_ci") == 0,
+              "collation_connection != latin2_general_ci");
 
   /* That's it. Cleanup. */
 
@@ -751,8 +756,9 @@ static int charset_auto(MYSQL *my __attribute__((unused)))
   csname1= mysql_character_set_name(mysql);
   diag("Character set: %s os charset: %s", csname1, osname);
 
-  FAIL_IF(strcmp(osname, csname1), "character set is not os character set");
-
+  FAIL_IF(!strcasecmp(osname,"utf8") ? strncmp(osname, csname1, 4) :
+                                       strcmp(osname, csname1),
+          "character set is not os character set");
   if (strcmp(osname, "utf8"))
   {
     rc= mysql_set_character_set(mysql, "utf8");
@@ -760,7 +766,6 @@ static int charset_auto(MYSQL *my __attribute__((unused)))
 
     csname2= mysql_character_set_name(mysql);
     diag("Character set: %s", csname2);
-
     FAIL_IF(!strcmp(csname2, csname1), "Wrong charset: expected utf8");
 
     rc= mysql_set_character_set(mysql, "auto");

--- a/unittest/libmariadb/connection.c
+++ b/unittest/libmariadb/connection.c
@@ -640,13 +640,12 @@ int test_conc21(MYSQL *mysql)
 int test_conc26(MYSQL *unused __attribute__((unused)))
 {
   MYSQL *mysql= mysql_init(NULL);
-  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8");
+  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "ascii");
 
   FAIL_IF(my_test_connect(mysql, hostname, "notexistinguser", "password", schema, port, NULL, CLIENT_REMEMBER_OPTIONS), 
           "Error expected");
-
-  FAIL_IF(!mysql->options.charset_name || strcmp(mysql->options.charset_name, "utf8") != 0, 
-          "expected charsetname=utf8");
+  FAIL_IF(!mysql->options.charset_name || strcmp(mysql->options.charset_name, "ascii") != 0,
+          "expected charsetname=ascii");
   mysql_close(mysql);
 
   mysql= mysql_init(NULL);
@@ -974,14 +973,15 @@ static int test_sess_track_db(MYSQL *mysql)
   if (mysql_get_server_version(mysql) >= 100300)
   {
     diag("charset: %s", mysql->charset->csname);
-    rc= mysql_query(mysql, "SET NAMES utf8");
+    rc= mysql_query(mysql, "SET NAMES ascii");
     check_mysql_rc(rc, mysql);
     if (!mysql_session_track_get_first(mysql, SESSION_TRACK_SYSTEM_VARIABLES, &data, &len))
     do {
       printf("# SESSION_TRACK_VARIABLES: %*.*s\n", (int)len, (int)len, data);
     } while (!mysql_session_track_get_next(mysql, SESSION_TRACK_SYSTEM_VARIABLES, &data, &len));
     diag("charset: %s", mysql->charset->csname);
-    FAIL_IF(strcmp(mysql->charset->csname, "utf8"), "Expected charset 'utf8'");
+    FAIL_IF(strcmp(mysql->charset->csname, "ascii"),
+            "Expected charset 'ascii'");
 
     rc= mysql_query(mysql, "SET NAMES latin1");
     check_mysql_rc(rc, mysql);

--- a/unittest/libmariadb/my_test.h
+++ b/unittest/libmariadb/my_test.h
@@ -700,4 +700,3 @@ void run_tests(struct my_tests_st *test) {
     mysql_close(mysql_default);
   }
 }
-


### PR DESCRIPTION
This patch is made as a part of MDEV-8334 to fix failing test in unit and
main test suite so that utf8mb3 characterset is recognized. Failing tests:
main.mysql_client_test
main.mysql_client_test_comp
unit.conc_basic-t
unit.conc_charset
unit.conc_connection