### PR TITLE
openssl: be strict on MA_HASH_CTX type

### DIFF
--- a/include/ma_crypt.h
+++ b/include/ma_crypt.h
@@ -55,7 +55,8 @@ typedef struct {
   DWORD digest_len;
 } MA_HASH_CTX;
 #elif defined(HAVE_OPENSSL)
-typedef void MA_HASH_CTX;
+#include <openssl/evp.h>
+typedef EVP_MD_CTX MA_HASH_CTX;
 #elif defined(HAVE_GNUTLS)
 typedef struct {
   void *ctx;


### PR DESCRIPTION
While a void typedef survived the compiles so far, in the Windows OpenSSL experiment it was discovered that the MA_HASH_CTX is only every EVP_MD_CTX so lets use that definition strictly for any other strict compiler that comes along.