### PR TITLE
Add support for ROWS_EVENT V2

### DIFF
--- a/include/mariadb_rpl.h
+++ b/include/mariadb_rpl.h
@@ -245,6 +245,8 @@ struct st_mariadb_rpl_rows_event {
   char *column_update_bitmap;
   size_t row_data_size;
   void *row_data;
+  size_t extra_data_size;
+  void *extra_data;
 };
 
 struct st_mariadb_rpl_heartbeat_event {

--- a/libmariadb/mariadb_rpl.c
+++ b/libmariadb/mariadb_rpl.c
@@ -348,9 +348,19 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
       break;
     }
     case WRITE_ROWS_EVENT_V1:
+    case WRITE_ROWS_EVENT:
     case UPDATE_ROWS_EVENT_V1:
+    case UPDATE_ROWS_EVENT:
     case DELETE_ROWS_EVENT_V1:
-      rpl_event->event.rows.type= rpl_event->event_type - WRITE_ROWS_EVENT_V1;
+    case DELETE_ROWS_EVENT:
+      if (rpl_event->event_type >= WRITE_ROWS_EVENT)
+      {
+        rpl_event->event.rows.type= rpl_event->event_type - WRITE_ROWS_EVENT;
+      }
+      else
+      {
+        rpl_event->event.rows.type= rpl_event->event_type - WRITE_ROWS_EVENT_V1;
+      }
       if (rpl->fd_header_len == 6)
       {
         rpl_event->event.rows.table_id= uint4korr(ev);
@@ -361,6 +371,25 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
       }
       rpl_event->event.rows.flags= uint2korr(ev);
       ev+= 2;
+      /* ROWS_EVENT V2 has the extra-data field.
+         See also: https://dev.mysql.com/doc/internals/en/rows-event.html
+      */
+      if (rpl_event->event_type >= WRITE_ROWS_EVENT)
+      {
+        rpl_event->event.rows.extra_data_size= uint2korr(ev) - 2;
+        ev+= 2;
+        if (rpl_event->event.rows.extra_data_size > 0)
+        {
+          if (!(rpl_event->event.rows.extra_data =
+                (char *)ma_alloc_root(&rpl_event->memroot,
+                                      rpl_event->event.rows.extra_data_size)))
+            goto mem_error;
+          memcpy(rpl_event->event.rows.extra_data,
+                 ev,
+                 rpl_event->event.rows.extra_data_size);
+          ev+= rpl_event->event.rows.extra_data_size;
+        }
+      }
       len= rpl_event->event.rows.column_count= mysql_net_field_length(&ev);
       if (!len)
         break;
@@ -369,7 +398,8 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
         goto mem_error;
       memcpy(rpl_event->event.rows.column_bitmap, ev, (len + 7) / 8);
       ev+= (len + 7) / 8;
-      if (rpl_event->event_type == UPDATE_ROWS_EVENT_V1)
+      if (rpl_event->event_type == UPDATE_ROWS_EVENT_V1 ||
+          rpl_event->event_type == UPDATE_ROWS_EVENT)
       {
         if (!(rpl_event->event.rows.column_update_bitmap =
             (char *)ma_alloc_root(&rpl_event->memroot, (len + 7) / 8)))
@@ -382,7 +412,7 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
       {
         if (!(rpl_event->event.rows.row_data =
             (char *)ma_alloc_root(&rpl_event->memroot, rpl_event->event.rows.row_data_size)))
-        goto mem_error;
+          goto mem_error;
         memcpy(rpl_event->event.rows.row_data, ev, rpl_event->event.rows.row_data_size);
       }
       break;


### PR DESCRIPTION
ROWS_EVENT V2 has the extra-data field after the flags field in
header.

See also: https://dev.mysql.com/doc/internals/en/rows-event.html