### PR TITLE
Fix for CONC-600: Do not release rpl_event if event_type is unknown

### DIFF
--- a/libmariadb/mariadb_rpl.c
+++ b/libmariadb/mariadb_rpl.c
@@ -443,8 +443,7 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
       }
       break;
     default:
-      mariadb_free_rpl_event(rpl_event);
-      return NULL;
+      return rpl_event;
       break;
     }
 


### PR DESCRIPTION
When i got a unsupport event_typ like `PREVIOUS_GTIDS_LOG_EVENT`, `mariadb_rpl_fetch` will free rpl_event and return null;
If my code is 
```
while ((event = mariadb_rpl_fetch(rpl, event)))
{
	//todo
}
```
 when i got unsupport event, the loop will finish.

I can check rpl->buffer_size out of function `mariadb_rpl_fetch` like
```
	while (1)
	{
		while ((event = mariadb_rpl_fetch(rpl, event)))
		{
			//todo
		}
		if (rpl->buffer_size == 0) break;
		unsupport_event_type = rpl->buffer[5];
               //todo
	}
```
 but `rpl_event->memroot` will be `ma_free_root` and `ma_init_alloc_root` in next call `mariadb_rpl_fetch`