### PR TITLE
fix for lseek c99 on osx

### DIFF
--- a/external/zlib/gzclose.c
+++ b/external/zlib/gzclose.c
@@ -4,6 +4,7 @@
  */
 
 #include "gzguts.h"
+#include <unistd.h>
 
 /* gzclose() is in a separate file so that it is linked in only if it is used.
    That way the other gzclose functions can be used instead to avoid linking in

--- a/external/zlib/gzlib.c
+++ b/external/zlib/gzlib.c
@@ -4,6 +4,8 @@
  */
 
 #include "gzguts.h"
+#include <unistd.h>
+
 
 #if defined(_WIN32) && !defined(__BORLANDC__)
 #  define LSEEK _lseeki64

--- a/external/zlib/gzread.c
+++ b/external/zlib/gzread.c
@@ -4,6 +4,7 @@
  */
 
 #include "gzguts.h"
+#include <unistd.h>
 
 /* Local functions */
 local int gz_load OF((gz_statep, unsigned char *, unsigned, unsigned *));

--- a/external/zlib/gzwrite.c
+++ b/external/zlib/gzwrite.c
@@ -4,6 +4,7 @@
  */
 
 #include "gzguts.h"
+#include <unistd.h>
 
 /* Local functions */
 local int gz_init OF((gz_statep));


### PR DESCRIPTION
Build is failing on mac ox monterey 12.4

with error:

```
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:254:9: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        LSEEK(state->fd, 0, SEEK_END);  /* so gzoffset() is correct */
        ^
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:254:9: note: did you mean 'fseek'?
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
/usr/local/include/stdio.h:162:6: note: 'fseek' declared here
int      fseek(FILE *, long, int);
         ^
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:260:24: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        state->start = LSEEK(state->fd, 0, SEEK_CUR);
                       ^
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:361:9: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    if (LSEEK(state->fd, state->start, SEEK_SET) == -1)
        ^
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:402:15: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        ret = LSEEK(state->fd, offset - (z_off64_t)state->x.have, SEEK_CUR);
              ^
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:498:14: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    offset = LSEEK(state->fd, 0, SEEK_CUR);
             ^
/Users/samuaz/Downloads/mariadb-connector-c-3.3.1-src/external/zlib/gzlib.c:14:17: note: expanded from macro 'LSEEK'
```

adding 

#include <unistd.h>

solve the issue tested on mac osx 12.4, archlinux and ubuntu