### PR TITLE
Add connection retry interval and support timeout for `pvio_socket_internal_connect`

### DIFF
--- a/plugins/pvio/pvio_socket.c
+++ b/plugins/pvio/pvio_socket.c
@@ -627,6 +627,10 @@ static int pvio_socket_internal_connect(MARIADB_PVIO *pvio,
   int rc= 0;
   struct st_pvio_socket *csock= NULL;
   int timeout;
+#ifndef _WIN32
+  unsigned int wait_conn= 1;
+  time_t start_t= time(NULL);
+#endif
 
   if (!pvio || !pvio->data)
     return 1;
@@ -640,6 +644,13 @@ static int pvio_socket_internal_connect(MARIADB_PVIO *pvio,
 #ifndef _WIN32
   do {
     rc= connect(csock->socket, (struct sockaddr*) name, (int)namelen);
+
+    if (time(NULL) - start_t > (time_t)timeout/1000)
+      break;
+
+    usleep(wait_conn);
+    wait_conn= wait_conn >= 1000000 ? 1000000 : wait_conn * 2;
+
   } while (rc == -1 && (errno == EINTR || errno == EAGAIN));
   /* in case a timeout values was set we need to check error values
      EINPROGRESS */


### PR DESCRIPTION
Add connection retry interval and support timeout for `pvio_socket_internal_connect`

There's an infinite loop in function `pvio_socket_internal_connect` to
retry connection forever if receiving specific errno number:
- No retry interval in the loop which will cause the process consuming all
  CPU usage and slowdown/stuck other processes.
- Even if the timeout was set in `mysqladmin` command option, the function
  will retry forever in the infinite loop.

The issue was seen a few times when MariaDB server was hanging and not
accepting new connection correctly. When the issue happened `mysqladmin`
process consumed 100% CPU usage and stack trace shows it stuck in the
loop. Though `--connect_timeout` was set in command line, `mysqladmin`
will never end until a force kill was executed.

In this commit a retry interval is added in the loop to avoid exhausting
the CPU resource. Also it will check the elapsed time in the loop and
break if it passed the timeout threshold.

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.