### PR TITLE
More robust call to X509_check_host using strlen not 0

### DIFF
--- a/libmariadb/secure/openssl.c
+++ b/libmariadb/secure/openssl.c
@@ -684,7 +684,7 @@ int ma_tls_verify_server_cert(MARIADB_TLS *ctls)
     return 1;
   }
 #ifdef HAVE_OPENSSL_CHECK_HOST
-  if (X509_check_host(cert, mysql->host, 0, 0, 0) != 1
+  if (X509_check_host(cert, mysql->host, strlen(mysql->host), 0, 0) != 1
      && X509_check_ip_asc(cert, mysql->host, 0) != 1)
     goto error;
 #else


### PR DESCRIPTION
Based on its interpretation of RFC 6125 section 6.4.2[^1], OpenSSL's
implementation[^2] of `X509_check_host` treats the `namelen` parameter
in a peculiar way:

- If `namelen` is non-zero, use it;
- Otherwise, use `strlen(name)` instead

There are now many forks of OpenSSL. Implementer of the forks may
interpret RFC 6125 section 6.4.2 a little differently. They may always
expect `strlen(name)` and NOT `0`. We have come across that with
AWS-LC[^3].  AWS-LC has agreed to make an adjustment so it is consistent
with OpenSSL in this matter. But other forks may not.

To make MariaDB connector C more robust, I think it's better that we
always pass `strlen(name)` instead of `0`. Unless there are compelling
reasons not doing so.

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.

[^1]: https://www.rfc-editor.org/rfc/rfc6125.html#section-6.4.2
[^2]: https://www.openssl.org/docs/man3.0/man3/X509_check_host.html
[^3]: https://github.com/awslabs/aws-lc