### PR TITLE
Fixed unexpected blocking in async codepaths w/SSL and other issues

### DIFF
--- a/include/ma_pvio.h
+++ b/include/ma_pvio.h
@@ -36,6 +36,8 @@ typedef struct st_ma_pvio_methods PVIO_METHODS;
 #define IS_MYSQL_ASYNC_ACTIVE(a) \
   (IS_MYSQL_ASYNC(a)&& (a)->options.extension->async_context->active)
 
+#define MATCH_PVIO_SYNC_OR_ASYNC(a) !IS_PVIO_ASYNC(a)
+
 enum enum_pvio_timeout {
   PVIO_CONNECT_TIMEOUT= 0,
   PVIO_READ_TIMEOUT,

--- a/libmariadb/ma_net.c
+++ b/libmariadb/ma_net.c
@@ -103,7 +103,7 @@ int ma_net_init(NET *net, MARIADB_PVIO* pvio)
   if (pvio != 0)					/* If real connection */
   {
     ma_pvio_get_handle(pvio, &net->fd);
-    ma_pvio_blocking(pvio, 1, 0);
+    ma_pvio_blocking(pvio, MATCH_PVIO_SYNC_OR_ASYNC(pvio), 0);
     ma_pvio_fast_send(pvio);
   }
   return 0;

--- a/plugins/pvio/pvio_socket.c
+++ b/plugins/pvio/pvio_socket.c
@@ -832,7 +832,7 @@ my_bool pvio_socket_connect(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo)
                     ER(CR_CONNECTION_ERROR), cinfo->unix_socket, socket_errno);
       goto error;
     }
-    if (pvio_socket_blocking(pvio, 1, 0) == SOCKET_ERROR)
+    if (pvio_socket_blocking(pvio, MATCH_PVIO_SYNC_OR_ASYNC(pvio), 0) == SOCKET_ERROR)
     {
       goto error;
     }
@@ -992,7 +992,7 @@ my_bool pvio_socket_connect(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo)
 #endif
       goto error;
     }
-    if (pvio_socket_blocking(pvio, 1, 0) == SOCKET_ERROR)
+    if (pvio_socket_blocking(pvio, MATCH_PVIO_SYNC_OR_ASYNC(pvio), 0) == SOCKET_ERROR)
       goto error;
   }
   /* apply timeouts */


### PR DESCRIPTION
- fixed https://jira.mariadb.org/browse/CONC-594
- fixed disabled 0s timeouts not handled correctly
- fixed pvio double free if async connect is aborted early via forced timeout