### PR TITLE
Fixed unexpected blocking in async codepaths w/SSL and other issues

### DIFF
--- a/include/ma_pvio.h
+++ b/include/ma_pvio.h
@@ -36,6 +36,8 @@ typedef struct st_ma_pvio_methods PVIO_METHODS;
 #define IS_MYSQL_ASYNC_ACTIVE(a) \
   (IS_MYSQL_ASYNC(a)&& (a)->options.extension->async_context->active)
 
+#define MATCH_PVIO_SYNC_OR_ASYNC(a) !IS_PVIO_ASYNC(a)
+
 enum enum_pvio_timeout {
   PVIO_CONNECT_TIMEOUT= 0,
   PVIO_READ_TIMEOUT,

--- a/libmariadb/ma_net.c
+++ b/libmariadb/ma_net.c
@@ -103,7 +103,7 @@ int ma_net_init(NET *net, MARIADB_PVIO* pvio)
   if (pvio != 0)					/* If real connection */
   {
     ma_pvio_get_handle(pvio, &net->fd);
-    ma_pvio_blocking(pvio, 1, 0);
+    ma_pvio_blocking(pvio, MATCH_PVIO_SYNC_OR_ASYNC(pvio), 0);
     ma_pvio_fast_send(pvio);
   }
   return 0;

--- a/plugins/pvio/pvio_socket.c
+++ b/plugins/pvio/pvio_socket.c
@@ -832,7 +832,7 @@ my_bool pvio_socket_connect(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo)
                     ER(CR_CONNECTION_ERROR), cinfo->unix_socket, socket_errno);
       goto error;
     }
-    if (pvio_socket_blocking(pvio, 1, 0) == SOCKET_ERROR)
+    if (pvio_socket_blocking(pvio, MATCH_PVIO_SYNC_OR_ASYNC(pvio), 0) == SOCKET_ERROR)
     {
       goto error;
     }
@@ -992,7 +992,7 @@ my_bool pvio_socket_connect(MARIADB_PVIO *pvio, MA_PVIO_CINFO *cinfo)
 #endif
       goto error;
     }
-    if (pvio_socket_blocking(pvio, 1, 0) == SOCKET_ERROR)
+    if (pvio_socket_blocking(pvio, MATCH_PVIO_SYNC_OR_ASYNC(pvio), 0) == SOCKET_ERROR)
       goto error;
   }
   /* apply timeouts */

--- a/unittest/libmariadb/async.c
+++ b/unittest/libmariadb/async.c
@@ -273,12 +273,16 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
     mysql_options(&mysql, MYSQL_READ_DEFAULT_GROUP, "myapp");
 
     /* Returns 0 when done, else flag for what to wait for when need to block. */
-    status= mysql_real_connect_start(&ret, &mysql, "0.0.0.0", username, password, schema, port, socketname, 0);
+    status= mysql_real_connect_start(&ret, &mysql, "1.2.3.4", username, password, schema, port, socketname, 0);
+    diag("status0: %d, pvio: %p", status, mysql.net.pvio);
     while (status)
     {
       status= wait_for_mysql(&mysql, status);
+      diag("status1: %d, pvio: %p", status, mysql.net.pvio);
       status= mysql_real_connect_cont(&ret, &mysql, status);
+      diag("status2: %d, pvio: %p", status, mysql.net.pvio);
     }
+    diag("status3 - mysql_errno: %d, mysql_err: %s", mysql_errno(&mysql), mysql_error(&mysql));
     if (!ret)
     {
       status= mysql_close_start(&mysql);
@@ -288,7 +292,7 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
         status= mysql_close_cont(&mysql, status);
       }
     } else {
-      diag("Expected error when connection to host '0.0.0.0'");
+      diag("Expected error when connection to host '1.2.3.4', mysql_errno: %d, mysql_err: %s", mysql_errno(&mysql), mysql_error(&mysql));
       return FAIL;
     }
   }

--- a/unittest/libmariadb/async.c
+++ b/unittest/libmariadb/async.c
@@ -288,7 +288,7 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
         status= mysql_close_cont(&mysql, status);
       }
     } else {
-      diag("Expected error when connection to host '0.0.0.0'");
+      diag("Expected error when connection to host '0.0.0.0', mysql_errno: %d, mysql_err: %s", mysql_errno(&mysql), mysql_error(&mysql));
       return FAIL;
     }
   }

--- a/unittest/libmariadb/async.c
+++ b/unittest/libmariadb/async.c
@@ -273,7 +273,7 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
     mysql_options(&mysql, MYSQL_READ_DEFAULT_GROUP, "myapp");
 
     /* Returns 0 when done, else flag for what to wait for when need to block. */
-    status= mysql_real_connect_start(&ret, &mysql, "0.0.0.0", username, password, schema, port, socketname, 0);
+    status= mysql_real_connect_start(&ret, &mysql, "1.2.3.4", username, password, schema, port, socketname, 0);
     diag("status0: %d, pvio: %p", status, mysql.net.pvio);
     while (status)
     {
@@ -282,6 +282,7 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
       status= mysql_real_connect_cont(&ret, &mysql, status);
       diag("status2: %d, pvio: %p", status, mysql.net.pvio);
     }
+    diag("status3 - mysql_errno: %d, mysql_err: %s", mysql_errno(&mysql), mysql_error(&mysql));
     if (!ret)
     {
       status= mysql_close_start(&mysql);
@@ -291,7 +292,7 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
         status= mysql_close_cont(&mysql, status);
       }
     } else {
-      diag("Expected error when connection to host '0.0.0.0', mysql_errno: %d, mysql_err: %s", mysql_errno(&mysql), mysql_error(&mysql));
+      diag("Expected error when connection to host '1.2.3.4', mysql_errno: %d, mysql_err: %s", mysql_errno(&mysql), mysql_error(&mysql));
       return FAIL;
     }
   }

--- a/unittest/libmariadb/async.c
+++ b/unittest/libmariadb/async.c
@@ -259,7 +259,7 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
   if (skip_async)
     return SKIP;
 
-  for (i=0; i < 100; i++)
+  for (i=0; i < 10; i++)
   {
     mysql_init(&mysql);
     rc= mysql_options(&mysql, MYSQL_OPT_NONBLOCK, 0);

--- a/unittest/libmariadb/async.c
+++ b/unittest/libmariadb/async.c
@@ -273,16 +273,12 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
     mysql_options(&mysql, MYSQL_READ_DEFAULT_GROUP, "myapp");
 
     /* Returns 0 when done, else flag for what to wait for when need to block. */
-    status= mysql_real_connect_start(&ret, &mysql, "1.2.3.4", username, password, schema, port, socketname, 0);
-    diag("status0: %d, pvio: %p", status, mysql.net.pvio);
+    status= mysql_real_connect_start(&ret, &mysql, "0.0.0.0", username, password, schema, port, socketname, 0);
     while (status)
     {
       status= wait_for_mysql(&mysql, status);
-      diag("status1: %d, pvio: %p", status, mysql.net.pvio);
       status= mysql_real_connect_cont(&ret, &mysql, status);
-      diag("status2: %d, pvio: %p", status, mysql.net.pvio);
     }
-    diag("status3 - mysql_errno: %d, mysql_err: %s", mysql_errno(&mysql), mysql_error(&mysql));
     if (!ret)
     {
       status= mysql_close_start(&mysql);
@@ -292,7 +288,7 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
         status= mysql_close_cont(&mysql, status);
       }
     } else {
-      diag("Expected error when connection to host '1.2.3.4', mysql_errno: %d, mysql_err: %s", mysql_errno(&mysql), mysql_error(&mysql));
+      diag("Expected error when connection to host '0.0.0.0'");
       return FAIL;
     }
   }

--- a/unittest/libmariadb/async.c
+++ b/unittest/libmariadb/async.c
@@ -274,10 +274,13 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
 
     /* Returns 0 when done, else flag for what to wait for when need to block. */
     status= mysql_real_connect_start(&ret, &mysql, "0.0.0.0", username, password, schema, port, socketname, 0);
+    diag("status0: %d, pvio: %p", status, mysql.net.pvio);
     while (status)
     {
       status= wait_for_mysql(&mysql, status);
+      diag("status1: %d, pvio: %p", status, mysql.net.pvio);
       status= mysql_real_connect_cont(&ret, &mysql, status);
+      diag("status2: %d, pvio: %p", status, mysql.net.pvio);
     }
     if (!ret)
     {

--- a/unittest/libmariadb/async.c
+++ b/unittest/libmariadb/async.c
@@ -273,7 +273,7 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
     mysql_options(&mysql, MYSQL_READ_DEFAULT_GROUP, "myapp");
 
     /* Returns 0 when done, else flag for what to wait for when need to block. */
-    status= mysql_real_connect_start(&ret, &mysql, "0.0.0.0", username, password, schema, port, socketname, 0);
+    status= mysql_real_connect_start(&ret, &mysql, "1.2.3.4", username, password, schema, port, socketname, 0);
     while (status)
     {
       status= wait_for_mysql(&mysql, status);
@@ -288,7 +288,7 @@ static int test_conc622(MYSQL *my __attribute__((unused)))
         status= mysql_close_cont(&mysql, status);
       }
     } else {
-      diag("Expected error when connection to host '0.0.0.0'");
+      diag("Expected error when connection to host '1.2.3.4'");
       return FAIL;
     }
   }


### PR DESCRIPTION
- unexpected thread blocking in async codepath (https://jira.mariadb.org/browse/CONC-594)
- disabled 0s timeouts not handled correctly
- pvio double free if async connect fails
- invalid usage of 0.0.0.0 IP by test_conc622 to test conn failure. Conn can unexpectedly succeed when server/client are co-located on host.