### PR TITLE
Fix trivial spelling errors

### DIFF
--- a/man/mariadb_get_infov.3
+++ b/man/mariadb_get_infov.3
@@ -5,7 +5,7 @@
 .hy
 .SS Name
 .PP
-mariadb_get_infov \- retrieves generic or connection releated
+mariadb_get_infov \- retrieves generic or connection related
 information
 .SS Synopsis
 .IP
@@ -170,7 +170,7 @@ Retrieves character set information for given connection.
 .PD 0
 .P
 .PD
-Returns the handshak capability flags] of the client.
+Returns the handshake capability flags] of the client.
 .IP \[bu] 2
 \f[C]MARIADB_CONNECTION_ERROR\f[R]
 .PD 0

--- a/man/mariadb_reconnect.3
+++ b/man/mariadb_reconnect.3
@@ -22,7 +22,7 @@ It uses the same credentials which were specified in
 \f[B]mysql_real_connect(3)\f[R].
 .SS Return value
 .PP
-The function will return 0 on sucess, a non zero value on error
+The function will return 0 on success, a non zero value on error
 .PP
 \f[B]Note\f[R]: The function will return an error, if the option
 \f[C]MYSQL_OPT_RECONNECT\f[R] wasn\[cq]t set before.

--- a/man/mysql_ping.3
+++ b/man/mysql_ping.3
@@ -36,7 +36,7 @@ Also resources bundled to the connection (prepared statements, locks,
 temporary tables, \&...) will be released.
 .SS Return value
 .PP
-Returns zero on success, nonzero if an error occured.
+Returns zero on success, nonzero if an error occurred.
 .SS See also
 .IP \[bu] 2
 \f[B]mysql_optionsv(3)\f[R]

--- a/man/mysql_real_connect.3
+++ b/man/mysql_real_connect.3
@@ -141,11 +141,11 @@ since version 3.3.0).
 The following syntax is required:
 .RS 2
 .IP \[bu] 2
-hostname and port must be seperated by a colon (:)
+hostname and port must be separated by a colon (:)
 .IP \[bu] 2
 IPv6 addresses must be enclosed within square brackets
 .IP \[bu] 2
-hostname:port pairs must be be seperated by a comma (,)
+hostname:port pairs must be be separated by a comma (,)
 .IP \[bu] 2
 if only one host:port was specified, the host string needs to end with a
 comma.

--- a/man/mysql_send_query.3
+++ b/man/mysql_send_query.3
@@ -5,7 +5,7 @@
 .SS Name
 .PP
 mysql_send_query \- sends a SQL statement without waiting for server
-reponse
+response
 .SS Synopsis
 .IP
 .nf

--- a/man/mysql_set_character_set.3
+++ b/man/mysql_set_character_set.3
@@ -34,7 +34,7 @@ of \f[C]SET NAMES ...\f[R] since \f[B]mysql_real_escape_string(3)\f[R]
 might fail or deliver unexpected results.
 .SS Return value
 .PP
-Zero on success, non zero if an error occured
+Zero on success, non zero if an error occurred
 .SS Supported character sets
 .PP
 The client library supports the following character sets:

--- a/man/mysql_stmt_error.3
+++ b/man/mysql_stmt_error.3
@@ -27,7 +27,7 @@ The string will be empty if no error occurred.
 .SS Return value
 .IP \[bu] 2
 A string describing the last error or an empty string if no error
-occured.
+occurred.
 .SS Notes
 .IP \[bu] 2
 Client error messages are listed in the \f[C]errmsg.h\f[R] header file,

--- a/man/mysql_stmt_reset.3
+++ b/man/mysql_stmt_reset.3
@@ -24,7 +24,7 @@ Resets a prepared statement on client and server to state after prepare.
 Returns zero on success, nonzero if an error occurred.
 .SS Return value
 .PP
-Returns zero on succes, 1 if an error occured.
+Returns zero on succes, 1 if an error occurred.
 .SS Notes
 .IP \[bu] 2
 \f[C]mysql_stmt_reset()\f[R] resets the statement on the server,

--- a/man/mysql_store_result.3
+++ b/man/mysql_store_result.3
@@ -31,7 +31,7 @@ allocated by \f[B]mysql_init(3)\f[R] and connected by
 \f[B]mysql_real_connect(3)\f[R].
 .SS Return value
 .PP
-Returns a buffered result set or NULL in case an error occured or if the
+Returns a buffered result set or NULL in case an error occurred or if the
 query didn\[cq]t return data (e.g.\ when executing an INSERT, UPDATE,
 DELETE or REPLACE statement).
 ## See also * \f[B]mysql_free_result(3)\f[R] *

--- a/unittest/libmariadb/result.c
+++ b/unittest/libmariadb/result.c
@@ -65,7 +65,7 @@ static int client_use_result(MYSQL *mysql)
   result= mysql_use_result(mysql);
   FAIL_IF(!result, "Invalid result set");
 
-  /* since we use use result, we shouldn't be able execute other api calls */
+  /* since we use result, we shouldn't be able execute other api calls */
   rc= mysql_ping(mysql);
   FAIL_IF(!rc, "Error expected");
 


### PR DESCRIPTION
- handshak -> handshake
- occured -> occurred
- releated -> related
- reponse -> response
- seperated -> separated
- sucess -> success
- use use -> use