### PR TITLE
MDEV-30587: TLS/SSL error: unexpected eof while reading

### DIFF
--- a/libmariadb/secure/openssl.c
+++ b/libmariadb/secure/openssl.c
@@ -463,6 +463,9 @@ my_bool ma_tls_connect(MARIADB_TLS *ctls)
   BIO_METHOD *bio_method= NULL;
   BIO *bio;
 #endif
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+  SSL_set_options(ssl, SSL_OP_IGNORE_UNEXPECTED_EOF);
+#endif
 
   mysql= (MYSQL *)SSL_get_app_data(ssl);
   pvio= mysql->net.pvio;


### PR DESCRIPTION
Since OpenSSL-3.0 there is this warning if the peer unexpected shutdown.

As MariaDB uses SSL_set_quiet_shutdown on the server side to perform an abrupt shutdown this leaves the client issuing warnings often on every TLS connection.

ref: https://github.com/openssl/openssl/issues/18866#issuecomment-1194219601