### PR TITLE
[MDEV-28634] Do not allow silent downgrade of connections where SSL is requested

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -1918,6 +1918,16 @@ restart:
     }
   }
 
+  /* We now know the server's capabilities. If the client wants TLS/SSL,
+   * but the server doesn't support it, we should immediately abort.
+   */
+  if (mysql->options.use_ssl && !(mysql->server_capabilities & CLIENT_SSL))
+  {
+    SET_CLIENT_ERROR(mysql, CR_SSL_CONNECTION_ERROR, SQLSTATE_UNKNOWN,
+                     "Client requires TLS/SSL, but the server does not support it");
+    goto error;
+  }
+
   /* Set character set */
   if (mysql->options.charset_name)
     mysql->charset= mysql_find_charset_name(mysql->options.charset_name);

--- a/plugins/auth/my_auth.c
+++ b/plugins/auth/my_auth.c
@@ -245,15 +245,6 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
     mysql->server_capabilities &= ~(CLIENT_SSL);
   }
 
-  /* if server doesn't support SSL, we need to return an error */
-  if (mysql->options.use_ssl && !(mysql->server_capabilities & CLIENT_SSL))
-  {
-    my_set_error(mysql, CR_SSL_CONNECTION_ERROR, SQLSTATE_UNKNOWN,
-                        ER(CR_SSL_CONNECTION_ERROR), 
-                        "SSL is required, but the server does not support it");
-    goto error;
-  }
-
   /* Remove options that server doesn't support */
   mysql->client_flag= mysql->client_flag &
                        (~(CLIENT_COMPRESS | CLIENT_ZSTD_COMPRESSION | CLIENT_SSL | CLIENT_PROTOCOL_41) 

--- a/plugins/auth/my_auth.c
+++ b/plugins/auth/my_auth.c
@@ -245,21 +245,14 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
     mysql->server_capabilities &= ~(CLIENT_SSL);
   }
 
-  /* if server doesn't support SSL and verification of server certificate
-     was set to mandatory, we need to return an error */
+  /* if server doesn't support SSL, we need to return an error */
   if (mysql->options.use_ssl && !(mysql->server_capabilities & CLIENT_SSL))
   {
-    if ((mysql->client_flag & CLIENT_SSL_VERIFY_SERVER_CERT) ||
-        (mysql->options.extension && (mysql->options.extension->tls_fp || 
-                                      mysql->options.extension->tls_fp_list)))
-    {
-      my_set_error(mysql, CR_SSL_CONNECTION_ERROR, SQLSTATE_UNKNOWN,
-                          ER(CR_SSL_CONNECTION_ERROR), 
-                          "SSL is required, but the server does not support it");
-      goto error;
-    }
+    my_set_error(mysql, CR_SSL_CONNECTION_ERROR, SQLSTATE_UNKNOWN,
+                        ER(CR_SSL_CONNECTION_ERROR), 
+                        "SSL is required, but the server does not support it");
+    goto error;
   }
-
 
   /* Remove options that server doesn't support */
   mysql->client_flag= mysql->client_flag &


### PR DESCRIPTION
The 2015 commit
https://github.com/mariadb-corporation/mariadb-connector-c/commit/23895fbd4#diff-4339ae6506ef1fb201f6f836085257e72c191d2b4498df507d499fc30d891005
was described as "Fixed gnutls support", which is an extremely incomplete
description of what it actually does.

In that commit, the Connector/C client authentication plugin was modified to
abort following the initial server greeting packet if the client has
requested a secure transport (`mariadb --ssl`), but the server does not
advertise support for SSL/TLS.

However, there's a crucial caveat here:

If the client has requested secure transport (`mariadb --ssl`) but has not
requested verification of the server's TLS certificate
(`mariadb --ssl --ssl-verify-server-cert`), then the client will silently
accept an unencrypted connection, without even printing a diagnostic message.

Thus, any such client is susceptible to a trivial downgrade to an
unencrypted connection by an on-path attacker who simply flips the TLS/SSL
capability bit in the advertised server capabilities in the greeting packet.

The entire design of MariaDB's TLS support is severely flawed in terms of
user expectations surrounding secure-by-default connections: the `--ssl`
option SHOULD imply `--ssl-verify-server-cert` BY DEFAULT; if a client
actually wants a TLS connection that's susceptible to a trivial MITM'ed
by any pervasive or on-path attacker, that should be an exceptional case
(e.g. `--insecure-ssl-without-server-cert-verification`) rather than the
default.

Even without resolving the issue of no default verification of server
certificates, the issue of silent downgrade to unencrypted connections can
and should be resolved.

Additionally, the second commit moves the check for server TLS/SSL capability from `send_client_reply_packet` (in `my_auth.c`) to `mthd_my_real_connect` (in `mariadb_lib.c`). Two reasons for this:

1. Reduction of attack surface

   As soon as the client receives the server's capability flags, it knows
   whether the server supports TLS/SSL.

   If the server does not support TLS/SSL, but the client expects and
   requires it, the client should immediately abort at this point in order
   to truncate any code paths by which it could inadvertently continue to
   communicate without TLS/SSL.

2. Separation of concerns

   Whether or not the server supports TLS/SSL encryption at the transport
   layer (TLS stands for TRANSPORT-layer security) is a logically separate
   issue from what APPLICATION-layer authentication modes the client and
   server support or should use.

# Backwards compatibility

This is an INTENTIONAL backwards-incompatible
change to prevent clients from being silently downgraded to unencrypted
connections, when they've specified `--ssl` and thus clearly indicated that
they do not want unencrypted connections.

