### PR TITLE
Add pipelined execution for the binary protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DDBUG_OFF
 
 IF(CMAKE_COMPILER_IS_GNUCC)
   INCLUDE(CheckCCompilerFlag)
-  SET(GCC_FLAGS -Wunused -Wlogical-op -Wno-uninitialized  -Wall -Wextra -Wformat-security -Wno-init-self -Wwrite-strings -Wshift-count-overflow -Wdeclaration-after-statement -Wno-undef -Wno-unknown-pragmas)
+  SET(GCC_FLAGS -Wunused -Wlogical-op -Wno-uninitialized -Werror -Wall -Wextra -Wformat-security -Wno-init-self -Wwrite-strings -Wshift-count-overflow -Wdeclaration-after-statement -Wno-undef -Wno-unknown-pragmas)
   FOREACH(GCC_FLAG ${GCC_FLAGS})
     CHECK_C_COMPILER_FLAG("${GCC_FLAG}" HAS_${GCC_FLAG}_FLAG)
     IF(${HAS_${GCC_FLAG}_FLAG})

--- a/libmariadb/mariadb_rpl.c
+++ b/libmariadb/mariadb_rpl.c
@@ -962,7 +962,7 @@ static uint8_t mariadb_rpl_send_semisync_ack(MARIADB_RPL* rpl, MARIADB_RPL_EVENT
     rpl_set_error(rpl, CR_BINLOG_SEMI_SYNC_ERROR, 0, "semi synchronous replication is not enabled");
     return 1;
   }
-  if (!event->is_semi_sync || !event->semi_sync_flags != SEMI_SYNC_ACK_REQ)
+  if (!event->is_semi_sync || event->semi_sync_flags != SEMI_SYNC_ACK_REQ)
   {
     rpl_set_error(rpl, CR_BINLOG_SEMI_SYNC_ERROR, 0, "This event doesn't require to send semi synchronous acknoledgement");
     return 1;
@@ -972,7 +972,7 @@ static uint8_t mariadb_rpl_send_semisync_ack(MARIADB_RPL* rpl, MARIADB_RPL_EVENT
   buf = alloca(buf_size);
 
   buf[0] = SEMI_SYNC_INDICATOR;
-  int8store(buf + 1, event->next_event_pos);
+  int8store(buf + 1, (uint64_t)event->next_event_pos);
   memcpy(buf + 9, rpl->filename, rpl->filename_length);
 
   ma_net_clear(&rpl->mysql->net);
@@ -2084,6 +2084,7 @@ int STDCALL mariadb_rpl_get_optionsv(MARIADB_RPL *rpl,
   {
     unsigned int* semi_sync = va_arg(ap, unsigned int*);
     *semi_sync = rpl->is_semi_sync;
+    break;
   }
 
   default:


### PR DESCRIPTION
The mysql_send_query() function allows text protocol queries to be executed in a batched manner, also known as pipelined execution of the queries. The batched execution for the text protocol is done by sending the queries before reading their results. This allows the sending of the query and reading of the result to be detached which eliminates the latency that would otherwise exist for normal serialized execution.

The same can be done for the binary protocol by splitting the execution of mysql_stmt_execute() into separate parts. This commit adds the extensions mariadb_stmt_send_execute() and
mariadb_stmt_read_execute_result(). They behave the same way a normal mysql_stmt_execute() would: the query parameter binds are bound before the query is sent and the result binds are bound once the results are read.

With pipelined execution supported for both text and binary protocols, bulk insertions can be done more efficiently on servers that do not implement the MariaDB bulk insertion API.

I tested this with the `10.11.3` docker image and all tests pass.