### PR TITLE
[CONC-654] Stop leaking client identifying information to the server before the TLS handshake

### DIFF
--- a/include/mariadb_com.h
+++ b/include/mariadb_com.h
@@ -162,6 +162,19 @@ enum enum_server_command
 #define CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS (1UL << 22)
 #define CLIENT_SESSION_TRACKING  (1UL << 23)
 #define CLIENT_ZSTD_COMPRESSION  (1UL << 26)
+/* This capability is set if:
+ *
+ * - The CLIENT knows how to send a truncated 2-byte SSLRequest
+ *   packet, containing no information other than the CLIENT_SSL flag
+ *   which is necessary to trigger the TLS handshake, and to send its
+ *   complete capability flags and other identifying information after
+ *   the TLS handshake.
+ * - The SERVER knows how to receive this truncated 2-byte SSLRequest
+ *   packet, and to receive the client's complete capability bits
+ *   after the TLS handshake.
+ *
+ */
+#define CLIENT_CAN_SSL_V2    (1ULL << 37)
 #define CLIENT_PROGRESS          (1UL << 29) /* client supports progress indicator */
 #define CLIENT_PROGRESS_OBSOLETE  CLIENT_PROGRESS 
 #define CLIENT_SSL_VERIFY_SERVER_CERT (1UL << 30)
@@ -219,7 +232,8 @@ enum enum_server_command
                                  CLIENT_PLUGIN_AUTH |\
                                  CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA | \
                                  CLIENT_SESSION_TRACKING |\
-                                 CLIENT_CONNECT_ATTRS)
+                                 CLIENT_CONNECT_ATTRS |\
+                                 CLIENT_CAN_SSL_V2)
 
 #define CLIENT_DEFAULT_FLAGS ((CLIENT_SUPPORTED_FLAGS & ~CLIENT_COMPRESS)\
                                                       & ~CLIENT_SSL)

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -1951,6 +1951,17 @@ restart:
 
   mysql->client_flag= client_flag;
 
+  /* Until run_plugin_auth has completed, the connection
+   * cannot have been secured with TLS/SSL.
+   *
+   * This means that any client which expects to use a
+   * TLS/SSL-secured connection SHOULD NOT trust any
+   * communication received from the server prior to this
+   * point as being genuine; nor should either the client
+   * or the server send any confidential information up
+   * to this point.
+   */
+
   if (run_plugin_auth(mysql, scramble_data, scramble_len,
                              scramble_plugin, db))
     goto error;

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -1787,7 +1787,12 @@ restart:
  */
   if ((pkt_length=ma_net_safe_read(mysql)) == packet_error)
   {
-    if (mysql->net.last_errno == CR_SERVER_LOST)
+    if (mysql->options.use_ssl)
+      my_set_error(mysql, CR_CONNECTION_ERROR, SQLSTATE_UNKNOWN,
+                   "Received error packet before completion of TLS handshake. "
+                   "Suppressing its details so that the client cannot vary its behavior "
+                   "based on this UNTRUSTED input.");
+    else if (mysql->net.last_errno == CR_SERVER_LOST)
       my_set_error(mysql, CR_SERVER_LOST, SQLSTATE_UNKNOWN,
                  ER(CR_SERVER_LOST_EXTENDED),
                  "handshake: reading initial communication packet",

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -1923,6 +1923,16 @@ restart:
     }
   }
 
+  /* We now know the server's capabilities. If the client wants TLS/SSL,
+   * but the server doesn't support it, we should immediately abort.
+   */
+  if (mysql->options.use_ssl && !(mysql->server_capabilities & CLIENT_SSL))
+  {
+    SET_CLIENT_ERROR(mysql, CR_SSL_CONNECTION_ERROR, SQLSTATE_UNKNOWN,
+                     "Client requires TLS/SSL, but the server does not support it");
+    goto error;
+  }
+
   /* Set character set */
   if (mysql->options.charset_name)
     mysql->charset= mysql_find_charset_name(mysql->options.charset_name);

--- a/plugins/auth/my_auth.c
+++ b/plugins/auth/my_auth.c
@@ -245,15 +245,6 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
     mysql->server_capabilities &= ~(CLIENT_SSL);
   }
 
-  /* if server doesn't support SSL, we need to return an error */
-  if (mysql->options.use_ssl && !(mysql->server_capabilities & CLIENT_SSL))
-  {
-    my_set_error(mysql, CR_SSL_CONNECTION_ERROR, SQLSTATE_UNKNOWN,
-                        ER(CR_SSL_CONNECTION_ERROR), 
-                        "SSL is required, but the server does not support it");
-    goto error;
-  }
-
   /* Remove options that server doesn't support */
   mysql->client_flag= mysql->client_flag &
                        (~(CLIENT_COMPRESS | CLIENT_ZSTD_COMPRESSION | CLIENT_SSL | CLIENT_PROTOCOL_41) 

--- a/plugins/auth/my_auth.c
+++ b/plugins/auth/my_auth.c
@@ -245,21 +245,14 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
     mysql->server_capabilities &= ~(CLIENT_SSL);
   }
 
-  /* if server doesn't support SSL and verification of server certificate
-     was set to mandatory, we need to return an error */
+  /* if server doesn't support SSL, we need to return an error */
   if (mysql->options.use_ssl && !(mysql->server_capabilities & CLIENT_SSL))
   {
-    if ((mysql->client_flag & CLIENT_SSL_VERIFY_SERVER_CERT) ||
-        (mysql->options.extension && (mysql->options.extension->tls_fp || 
-                                      mysql->options.extension->tls_fp_list)))
-    {
-      my_set_error(mysql, CR_SSL_CONNECTION_ERROR, SQLSTATE_UNKNOWN,
-                          ER(CR_SSL_CONNECTION_ERROR), 
-                          "SSL is required, but the server does not support it");
-      goto error;
-    }
+    my_set_error(mysql, CR_SSL_CONNECTION_ERROR, SQLSTATE_UNKNOWN,
+                        ER(CR_SSL_CONNECTION_ERROR), 
+                        "SSL is required, but the server does not support it");
+    goto error;
   }
-
 
   /* Remove options that server doesn't support */
   mysql->client_flag= mysql->client_flag &

--- a/plugins/auth/my_auth.c
+++ b/plugins/auth/my_auth.c
@@ -321,8 +321,19 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
       (mysql->client_flag & CLIENT_SSL))
   {
     /*
-      Send mysql->client_flag, max_packet_size - unencrypted otherwise
-      the server does not know we want to do SSL
+      Send UNENCRYPTED "Login Request" packet with mysql->client_flag
+      and max_packet_size, but no username; without this, the server
+      does not know we want to switch to SSL/TLS
+
+      FIXME: Sending this packet is a very very VERY bad idea. It
+      contains the client's preferred charset and flags in plaintext;
+      this can be used for fingerprinting the client software version,
+      and probable geographic location.
+
+      This offers a glaring opportunity for pervasive attackers to
+      easily target, intercept, and exploit the client-server
+      connection (e.g. "MITM all connections from known-vulnerable
+      client versions originating from countries X, Y, and Z").
     */
     if (ma_net_write(net, (unsigned char *)buff, (size_t) (end-buff)) || ma_net_flush(net))
     {
@@ -332,6 +343,9 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
                           errno);
       goto error;
     }
+    /* This is where the socket is actually converted from a plain
+     * TCP/IP socket to a TLS/SSL-wrapped socket.
+     */
     if (ma_pvio_start_ssl(mysql->net.pvio))
       goto error;
   }


### PR DESCRIPTION
The server implementation here was incorrect as well, unnecessarily
reading—and TRUSTING—client identifying information sent before the TLS
handshake.  That's in [MDEV-31585](https://gitlab.aws.dev/rds/mariadb/-/merge_requests/110).

As a result of the server's mishandling of this information, it's not
possible for the client to fix this in a way that's backwards-compatible
with old servers.

We rely on the server sending a capability bit to indicate that the
server-side bug has been fixed:

```c
/* Server does not mishandle information sent in the plaintext
 * login request packet sent prior to the TLS handshake. As a result, the
 * client can safely send an empty/dummy packet contianing no
 * identifying information. Indicates that MDEV-31585 has been fixed.
 * Since ??.?.
 */
#define MARIADB_CLIENT_CAN_SEND_DUMMY_HANDSHAKE_PACKET    (1ULL << 37)
```

---

This PR also incorporates fixes for two previously-identified client-security vulnerabilities:

- [MDEV-28634](https://jira.mariadb.org/browse/MDEV-28634) ("improper TLS→plaintext downgrade"), also available as a standalone PR in https://github.com/mariadb-corporation/mariadb-connector-c/pull/224
- [CONC-648](https://jira.mariadb.org/browse/CONC-648) ("client improperly trusts server error packets sent prior to TLS handshake"), also available as a standalone PR in https://github.com/mariadb-corporation/mariadb-connector-c/pull/223
