### PR TITLE
Align stack correctly when initializing a context

### DIFF
--- a/libmariadb/ma_context.c
+++ b/libmariadb/ma_context.c
@@ -450,6 +450,11 @@ my_context_spawn(struct my_context *c, void (*f)(void *), void *d)
      */
      ".cfi_escape 0x07, 8\n\t"
 #endif
+     /*
+      * we'll push the arg on the stack. Skipping the first 12 bytes will mean the
+      * stack is re-aligned on a 16-byte address when we jump to "f".
+      */
+     "sub $12, %%esp\n\t"
      /* Push the parameter on the stack. */
      "pushl %[d]\n\t"
      "movl %%ebp, 4(%[save])\n\t"

--- a/unittest/libmariadb/CMakeLists.txt
+++ b/unittest/libmariadb/CMakeLists.txt
@@ -26,7 +26,7 @@ INCLUDE_DIRECTORIES(${CC_SOURCE_DIR}/include
                     ${CC_SOURCE_DIR}/unittest/libmariadb)
 ADD_DEFINITIONS(-DLIBMARIADB)
 
-SET(API_TESTS "conc336" "bulk1" "performance" "basic-t" "fetch" "charset" "logs" "cursor" "errors" "view" "ps" "ps_bugs" "sp" "result" "connection" "misc" "ps_new" "thread" "features-10_2")
+SET(API_TESTS "conc336" "bulk1" "performance" "basic-t" "fetch" "charset" "logs" "cursor" "errors" "view" "ps" "ps_bugs" "sp" "result" "connection" "misc" "ps_new" "thread" "features-10_2" "context")
 IF(WITH_DYNCOL)
   SET(API_TESTS ${API_TESTS} "dyncol")
 ENDIF()

--- a/unittest/libmariadb/context.c
+++ b/unittest/libmariadb/context.c
@@ -1,0 +1,44 @@
+/*
+ * Tests for ma_context functions.
+ */
+
+#include "my_test.h"
+#include "mysql.h"
+#include "ma_context.h"
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+
+/*
+ * Ensures the context system aligns the stack correctly for i386 and x86_64
+ */
+void async_task(__attribute__((unused)) void *v) {
+#if defined( __GNUC__ ) && ( defined( __i386__ ) || defined( __x86_64__ ) )
+    /*
+     * The compiler assumes the stack is correctly aligned on a 16-byte
+     * boundary on entry to the function (actually, with a return address
+     * popped on top of the aligned address). Creating an object with a
+     * max_align_t type should also be aligned at that boundary, so we should
+     * be able to use movaps to move the first 128 bits into  xmm0.
+     */
+    union {
+        max_align_t aligned;
+        uint64_t data[2];
+    } aligned;
+    __asm__("movaps %0, %%xmm0" : : "m" (aligned.data) : "xmm0" );
+#endif
+}
+
+static int test_stack_align() {
+    struct my_context ctx;
+    my_context_init(&ctx, 65536);
+    my_context_spawn(&ctx, async_task, &ctx);
+    my_context_destroy(&ctx);
+    return 0;
+}
+
+int main()
+{
+    plan(1);
+    ok( test_stack_align() == 0, "stack alignment check" );
+}


### PR DESCRIPTION
In `my_context_spawn`, assuming the allocated stack pointer is 16-bye aligned (as it will be from malloc, etc), align the stack correctly before calling the target function of the context.

For i686 platform, The Linux ABI requires that the stack is aligned on a 16-byte boundary at the time that a call is made, and the compiler attempts to maintain that alignment by adjusting the stack as required to meet the alignment requirements for data, and any subsequent calls.

This is particularly important when compiling for i386 platform with -msse2, The compiler can use SSE2 instructions like `movaps`, This instruction will actually fault on unalgned access. This causes the mariadb test suite to fail with the following error, for example:

```
main.non_blocking_api                    w4 [ fail ]
        Test ended at 2023-08-18 00:33:40

CURRENT_TEST: main.non_blocking_api
mysqltest got signal 11
read_command_buf (0x89a2a88): connect (con_nonblock,localhost,root,,test)

conn->name (0x89c7208):

Attempting backtrace...
stack_bottom = 0x0 thread_stack 0x10000
mysys/stacktrace.c:213(my_print_stacktrace)[0x80a7348]
bits/stdio2.h:97(fprintf)[0x80615f2]
addr2line: '': No such file
[0xf7ee8560]
??:0(BIO_f_buffer)[0xf7bc1ca1]
??:0(BIO_vsnprintf)[0xf7bc2aa1]
??:0(BIO_snprintf)[0xf7bc2af4]
??:0(ASN1_UTCTIME_adj)[0xf7be0875]
??:0(X509_time_adj_ex)[0xf7c062dd]
??:0(X509_time_adj)[0xf7c06312]
??:0(X509_cmp_time)[0xf7c06516]
??:0(X509_cmp_time)[0xf7c06720]
??:0(X509_verify_cert)[0xf7c08641]
??:0(ssl_verify_cert_chain)[0xf7d172e1]
??:0(ssl3_get_server_certificate)[0xf7cefc96]
??:0(ssl3_connect)[0xf7cf520b]
??:0(ssl23_connect)[0xf7cfee42]
secure/openssl.c:487(ma_tls_connect)[0x808ac22]
libmariadb/ma_tls.c:83(ma_pvio_tls_connect)[0x807d82d]
libmariadb/ma_pvio.c:531(ma_pvio_start_ssl)[0x807d553]
auth/my_auth.c:318(send_client_reply_packet)[0x808f5db]
auth/my_auth.c:94(native_password_auth_client)[0x808f84e]
auth/my_auth.c:620(run_plugin_auth)[0x808fb5c]
libmariadb/mariadb_lib.c:1665(mthd_my_real_connect)[0x807a121]
libmariadb/mariadb_async.c:332(mysql_real_connect_start_internal)[0x808b3d9]
libmariadb/ma_context.c:440(my_context_spawn)[0x808ed69]
libmariadb/mariadb_lib.c:3927(mariadb_get_socket)[0x8078c6f]
tests/nonblock-wrappers.h:96(wait_for_mysql(st_mysql*, int))[0x806117e]
```

In this case, the eventual crash is in openssl code, but this is a conseqeunce of a `movaps` instruction in `BIO_f_buffer` acting on an unaligned stack location, which is in turn a result of the unaligned stack from my_context_spawn. Any use of SSE2 instructions requiring alignment will fail in the same way