### PR TITLE
3.3 Refactor zlib functions to use modern prototype declaration and avoid warnings.

### DIFF
--- a/external/zlib/adler32.c
+++ b/external/zlib/adler32.c
@@ -13,10 +13,10 @@ local uLong adler32_combine_ OF((uLong adler1, uLong adler2, z_off64_t len2));
 #define NMAX 5552
 /* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
 
-#define DO1(buf,i)  {adler += (buf)[i]; sum2 += adler;}
-#define DO2(buf,i)  DO1(buf,i); DO1(buf,i+1);
-#define DO4(buf,i)  DO2(buf,i); DO2(buf,i+2);
-#define DO8(buf,i)  DO4(buf,i); DO4(buf,i+4);
+#define DO1(buf, i)  {adler += (buf)[i]; sum2 += adler;}
+#define DO2(buf, i)  DO1(buf,i); DO1(buf,i+1);
+#define DO4(buf, i)  DO2(buf,i); DO2(buf,i+2);
+#define DO8(buf, i)  DO4(buf,i); DO4(buf,i+4);
 #define DO16(buf)   DO8(buf,0); DO8(buf,8);
 
 /* use NO_DIVIDE if your processor does not do division in hardware --
@@ -60,11 +60,8 @@ local uLong adler32_combine_ OF((uLong adler1, uLong adler2, z_off64_t len2));
 #endif
 
 /* ========================================================================= */
-uLong ZEXPORT adler32_z(adler, buf, len)
-    uLong adler;
-    const Bytef *buf;
-    z_size_t len;
-{
+
+uLong ZEXPORT adler32_z(uLong adler, const Bytef *buf, z_size_t len) {
     unsigned long sum2;
     unsigned n;
 
@@ -131,20 +128,12 @@ uLong ZEXPORT adler32_z(adler, buf, len)
 }
 
 /* ========================================================================= */
-uLong ZEXPORT adler32(adler, buf, len)
-    uLong adler;
-    const Bytef *buf;
-    uInt len;
-{
+uLong ZEXPORT adler32(uLong adler, const Bytef *buf, uInt len) {
     return adler32_z(adler, buf, len);
 }
 
 /* ========================================================================= */
-local uLong adler32_combine_(adler1, adler2, len2)
-    uLong adler1;
-    uLong adler2;
-    z_off64_t len2;
-{
+local uLong adler32_combine_(uLong adler1, uLong adler2, z_off64_t len2) {
     unsigned long sum1;
     unsigned long sum2;
     unsigned rem;
@@ -155,7 +144,7 @@ local uLong adler32_combine_(adler1, adler2, len2)
 
     /* the derivation of this formula is left as an exercise for the reader */
     MOD63(len2);                /* assumes len2 >= 0 */
-    rem = (unsigned)len2;
+    rem = (unsigned) len2;
     sum1 = adler1 & 0xffff;
     sum2 = rem * sum1;
     MOD(sum2);
@@ -163,24 +152,16 @@ local uLong adler32_combine_(adler1, adler2, len2)
     sum2 += ((adler1 >> 16) & 0xffff) + ((adler2 >> 16) & 0xffff) + BASE - rem;
     if (sum1 >= BASE) sum1 -= BASE;
     if (sum1 >= BASE) sum1 -= BASE;
-    if (sum2 >= ((unsigned long)BASE << 1)) sum2 -= ((unsigned long)BASE << 1);
+    if (sum2 >= ((unsigned long) BASE << 1)) sum2 -= ((unsigned long) BASE << 1);
     if (sum2 >= BASE) sum2 -= BASE;
     return sum1 | (sum2 << 16);
 }
 
 /* ========================================================================= */
-uLong ZEXPORT adler32_combine(adler1, adler2, len2)
-    uLong adler1;
-    uLong adler2;
-    z_off_t len2;
-{
+uLong ZEXPORT adler32_combine(uLong adler1, uLong adler2, z_off_t len2) {
     return adler32_combine_(adler1, adler2, len2);
 }
 
-uLong ZEXPORT adler32_combine64(adler1, adler2, len2)
-    uLong adler1;
-    uLong adler2;
-    z_off64_t len2;
-{
+uLong ZEXPORT adler32_combine64(uLong adler1, uLong adler2, z_off64_t len2) {
     return adler32_combine_(adler1, adler2, len2);
 }

--- a/external/zlib/compress.c
+++ b/external/zlib/compress.c
@@ -6,6 +6,7 @@
 /* @(#) $Id$ */
 
 #define ZLIB_INTERNAL
+
 #include "zlib.h"
 
 /* ===========================================================================
@@ -19,40 +20,34 @@
    memory, Z_BUF_ERROR if there was not enough room in the output buffer,
    Z_STREAM_ERROR if the level parameter is invalid.
 */
-int ZEXPORT compress2(dest, destLen, source, sourceLen, level)
-    Bytef *dest;
-    uLongf *destLen;
-    const Bytef *source;
-    uLong sourceLen;
-    int level;
-{
+int ZEXPORT compress2(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen, int level) {
     z_stream stream;
     int err;
-    const uInt max = (uInt)-1;
+    const uInt max = (uInt) -1;
     uLong left;
 
     left = *destLen;
     *destLen = 0;
 
-    stream.zalloc = (alloc_func)0;
-    stream.zfree = (free_func)0;
-    stream.opaque = (voidpf)0;
+    stream.zalloc = (alloc_func) 0;
+    stream.zfree = (free_func) 0;
+    stream.opaque = (voidpf) 0;
 
     err = deflateInit(&stream, level);
     if (err != Z_OK) return err;
 
     stream.next_out = dest;
     stream.avail_out = 0;
-    stream.next_in = (z_const Bytef *)source;
+    stream.next_in = (z_const Bytef *) source;
     stream.avail_in = 0;
 
     do {
         if (stream.avail_out == 0) {
-            stream.avail_out = left > (uLong)max ? max : (uInt)left;
+            stream.avail_out = left > (uLong) max ? max : (uInt) left;
             left -= stream.avail_out;
         }
         if (stream.avail_in == 0) {
-            stream.avail_in = sourceLen > (uLong)max ? max : (uInt)sourceLen;
+            stream.avail_in = sourceLen > (uLong) max ? max : (uInt) sourceLen;
             sourceLen -= stream.avail_in;
         }
         err = deflate(&stream, sourceLen ? Z_NO_FLUSH : Z_FINISH);
@@ -65,12 +60,7 @@ int ZEXPORT compress2(dest, destLen, source, sourceLen, level)
 
 /* ===========================================================================
  */
-int ZEXPORT compress(dest, destLen, source, sourceLen)
-    Bytef *dest;
-    uLongf *destLen;
-    const Bytef *source;
-    uLong sourceLen;
-{
+int ZEXPORT compress(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen) {
     return compress2(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
 }
 
@@ -78,9 +68,7 @@ int ZEXPORT compress(dest, destLen, source, sourceLen)
      If the default memLevel or windowBits for deflateInit() is changed, then
    this function needs to be updated.
  */
-uLong ZEXPORT compressBound(sourceLen)
-    uLong sourceLen;
-{
+uLong ZEXPORT compressBound(uLong sourceLen) {
     return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) +
            (sourceLen >> 25) + 13;
 }

--- a/external/zlib/crc32.c
+++ b/external/zlib/crc32.c
@@ -29,26 +29,26 @@
 
 #include "zutil.h"      /* for Z_U4, Z_U8, z_crc_t, and FAR definitions */
 
- /*
-  A CRC of a message is computed on N braids of words in the message, where
-  each word consists of W bytes (4 or 8). If N is 3, for example, then three
-  running sparse CRCs are calculated respectively on each braid, at these
-  indices in the array of words: 0, 3, 6, ..., 1, 4, 7, ..., and 2, 5, 8, ...
-  This is done starting at a word boundary, and continues until as many blocks
-  of N * W bytes as are available have been processed. The results are combined
-  into a single CRC at the end. For this code, N must be in the range 1..6 and
-  W must be 4 or 8. The upper limit on N can be increased if desired by adding
-  more #if blocks, extending the patterns apparent in the code. In addition,
-  crc32.h would need to be regenerated, if the maximum N value is increased.
+/*
+ A CRC of a message is computed on N braids of words in the message, where
+ each word consists of W bytes (4 or 8). If N is 3, for example, then three
+ running sparse CRCs are calculated respectively on each braid, at these
+ indices in the array of words: 0, 3, 6, ..., 1, 4, 7, ..., and 2, 5, 8, ...
+ This is done starting at a word boundary, and continues until as many blocks
+ of N * W bytes as are available have been processed. The results are combined
+ into a single CRC at the end. For this code, N must be in the range 1..6 and
+ W must be 4 or 8. The upper limit on N can be increased if desired by adding
+ more #if blocks, extending the patterns apparent in the code. In addition,
+ crc32.h would need to be regenerated, if the maximum N value is increased.
 
-  N and W are chosen empirically by benchmarking the execution time on a given
-  processor. The choices for N and W below were based on testing on Intel Kaby
-  Lake i7, AMD Ryzen 7, ARM Cortex-A57, Sparc64-VII, PowerPC POWER9, and MIPS64
-  Octeon II processors. The Intel, AMD, and ARM processors were all fastest
-  with N=5, W=8. The Sparc, PowerPC, and MIPS64 were all fastest at N=5, W=4.
-  They were all tested with either gcc or clang, all using the -O3 optimization
-  level. Your mileage may vary.
- */
+ N and W are chosen empirically by benchmarking the execution time on a given
+ processor. The choices for N and W below were based on testing on Intel Kaby
+ Lake i7, AMD Ryzen 7, ARM Cortex-A57, Sparc64-VII, PowerPC POWER9, and MIPS64
+ Octeon II processors. The Intel, AMD, and ARM processors were all fastest
+ with N=5, W=8. The Sparc, PowerPC, and MIPS64 were all fastest at N=5, W=4.
+ They were all tested with either gcc or clang, all using the -O3 optimization
+ level. Your mileage may vary.
+*/
 
 /* Define N */
 #ifdef Z_TESTN
@@ -88,11 +88,11 @@
 #endif
 #ifdef W
 #  if W == 8 && defined(Z_U8)
-     typedef Z_U8 z_word_t;
+typedef Z_U8 z_word_t;
 #  elif defined(Z_U4)
 #    undef W
 #    define W 4
-     typedef Z_U4 z_word_t;
+typedef Z_U4 z_word_t;
 #  else
 #    undef W
 #  endif
@@ -105,15 +105,16 @@
 
 /* Local functions. */
 local z_crc_t multmodp OF((z_crc_t a, z_crc_t b));
+
 local z_crc_t x2nmodp OF((z_off64_t n, unsigned k));
 
 #if defined(W) && (!defined(ARMCRC32) || defined(DYNAMIC_CRC_TABLE))
-    local z_word_t byte_swap OF((z_word_t word));
+local z_word_t byte_swap OF((z_word_t word));
 #endif
 
 #if defined(W) && !defined(ARMCRC32)
-    local z_crc_t crc_word OF((z_word_t data));
-    local z_word_t crc_word_big OF((z_word_t data));
+local z_crc_t crc_word OF((z_word_t data));
+local z_word_t crc_word_big OF((z_word_t data));
 #endif
 
 #if defined(W) && (!defined(ARMCRC32) || defined(DYNAMIC_CRC_TABLE))
@@ -123,9 +124,7 @@ local z_crc_t x2nmodp OF((z_off64_t n, unsigned k));
   instruction, if one is available. This assumes that word_t is either 32 bits
   or 64 bits.
  */
-local z_word_t byte_swap(word)
-    z_word_t word;
-{
+local z_word_t byte_swap(z_word_t word){
 #  if W == 8
     return
         (word & 0xff00000000000000) >> 56 |
@@ -537,6 +536,7 @@ local void braid(ltl, big, n, w)
  * of x for combining CRC-32s, all made by make_crc_table().
  */
 #include "crc32.h"
+
 #endif /* DYNAMIC_CRC_TABLE */
 
 /* ========================================================================
@@ -548,13 +548,10 @@ local void braid(ltl, big, n, w)
   Return a(x) multiplied by b(x) modulo p(x), where p(x) is the CRC polynomial,
   reflected. For speed, this requires that a not be zero.
  */
-local z_crc_t multmodp(a, b)
-    z_crc_t a;
-    z_crc_t b;
-{
+local z_crc_t multmodp(z_crc_t a, z_crc_t b) {
     z_crc_t m, p;
 
-    m = (z_crc_t)1 << 31;
+    m = (z_crc_t) 1 << 31;
     p = 0;
     for (;;) {
         if (a & m) {
@@ -572,13 +569,10 @@ local z_crc_t multmodp(a, b)
   Return x^(n * 2^k) modulo p(x). Requires that x2n_table[] has been
   initialized.
  */
-local z_crc_t x2nmodp(n, k)
-    z_off64_t n;
-    unsigned k;
-{
+local z_crc_t x2nmodp(z_off64_t n, unsigned k) {
     z_crc_t p;
 
-    p = (z_crc_t)1 << 31;           /* x^0 == 1 */
+    p = (z_crc_t) 1 << 31;           /* x^0 == 1 */
     while (n) {
         if (n & 1)
             p = multmodp(x2n_table[k & 31], p);
@@ -592,12 +586,11 @@ local z_crc_t x2nmodp(n, k)
  * This function can be used by asm versions of crc32(), and to force the
  * generation of the CRC tables in a threaded application.
  */
-const z_crc_t FAR * ZEXPORT get_crc_table()
-{
+const z_crc_t FAR *ZEXPORT get_crc_table() {
 #ifdef DYNAMIC_CRC_TABLE
     once(&made, make_crc_table);
 #endif /* DYNAMIC_CRC_TABLE */
-    return (const z_crc_t FAR *)crc_table;
+    return (const z_crc_t FAR *) crc_table;
 }
 
 /* =========================================================================
@@ -619,11 +612,7 @@ const z_crc_t FAR * ZEXPORT get_crc_table()
 #define Z_BATCH_ZEROS 0xa10d3d0c    /* computed from Z_BATCH = 3990 */
 #define Z_BATCH_MIN 800             /* fewest words in a final batch */
 
-unsigned long ZEXPORT crc32_z(crc, buf, len)
-    unsigned long crc;
-    const unsigned char FAR *buf;
-    z_size_t len;
-{
+unsigned long ZEXPORT crc32_z(    unsigned long crc,    const unsigned char FAR *buf,    z_size_t len){
     z_crc_t val;
     z_word_t crc1, crc2;
     const z_word_t *word;
@@ -723,18 +712,14 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
   least-significant byte of the word as the first byte of data, without any pre
   or post conditioning. This is used to combine the CRCs of each braid.
  */
-local z_crc_t crc_word(data)
-    z_word_t data;
-{
+local z_crc_t crc_word(z_word_t data){
     int k;
     for (k = 0; k < W; k++)
         data = (data >> 8) ^ crc_table[data & 0xff];
     return (z_crc_t)data;
 }
 
-local z_word_t crc_word_big(data)
-    z_word_t data;
-{
+local z_word_t crc_word_big(z_word_t data) {
     int k;
     for (k = 0; k < W; k++)
         data = (data << 8) ^
@@ -745,11 +730,7 @@ local z_word_t crc_word_big(data)
 #endif
 
 /* ========================================================================= */
-unsigned long ZEXPORT crc32_z(crc, buf, len)
-    unsigned long crc;
-    const unsigned char FAR *buf;
-    z_size_t len;
-{
+unsigned long ZEXPORT crc32_z(unsigned long crc, const unsigned char FAR *buf, z_size_t len) {
     /* Return initial CRC, if requested. */
     if (buf == Z_NULL) return 0;
 
@@ -1069,20 +1050,12 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
 #endif
 
 /* ========================================================================= */
-unsigned long ZEXPORT crc32(crc, buf, len)
-    unsigned long crc;
-    const unsigned char FAR *buf;
-    uInt len;
-{
+unsigned long ZEXPORT crc32(unsigned long crc, const unsigned char FAR *buf, uInt len) {
     return crc32_z(crc, buf, len);
 }
 
 /* ========================================================================= */
-uLong ZEXPORT crc32_combine64(crc1, crc2, len2)
-    uLong crc1;
-    uLong crc2;
-    z_off64_t len2;
-{
+uLong ZEXPORT crc32_combine64(uLong crc1, uLong crc2, z_off64_t len2) {
 #ifdef DYNAMIC_CRC_TABLE
     once(&made, make_crc_table);
 #endif /* DYNAMIC_CRC_TABLE */
@@ -1090,18 +1063,12 @@ uLong ZEXPORT crc32_combine64(crc1, crc2, len2)
 }
 
 /* ========================================================================= */
-uLong ZEXPORT crc32_combine(crc1, crc2, len2)
-    uLong crc1;
-    uLong crc2;
-    z_off_t len2;
-{
-    return crc32_combine64(crc1, crc2, (z_off64_t)len2);
+uLong ZEXPORT crc32_combine(uLong crc1, uLong crc2, z_off_t len2) {
+    return crc32_combine64(crc1, crc2, (z_off64_t) len2);
 }
 
 /* ========================================================================= */
-uLong ZEXPORT crc32_combine_gen64(len2)
-    z_off64_t len2;
-{
+uLong ZEXPORT crc32_combine_gen64(z_off64_t len2) {
 #ifdef DYNAMIC_CRC_TABLE
     once(&made, make_crc_table);
 #endif /* DYNAMIC_CRC_TABLE */
@@ -1109,17 +1076,11 @@ uLong ZEXPORT crc32_combine_gen64(len2)
 }
 
 /* ========================================================================= */
-uLong ZEXPORT crc32_combine_gen(len2)
-    z_off_t len2;
-{
-    return crc32_combine_gen64((z_off64_t)len2);
+uLong ZEXPORT crc32_combine_gen(z_off_t len2) {
+    return crc32_combine_gen64((z_off64_t) len2);
 }
 
 /* ========================================================================= */
-uLong ZEXPORT crc32_combine_op(crc1, crc2, op)
-    uLong crc1;
-    uLong crc2;
-    uLong op;
-{
+uLong ZEXPORT crc32_combine_op(uLong crc1, uLong crc2, uLong op) {
     return multmodp(op, crc1) ^ (crc2 & 0xffffffff);
 }

--- a/external/zlib/deflate.c
+++ b/external/zlib/deflate.c
@@ -52,7 +52,7 @@
 #include "deflate.h"
 
 const char deflate_copyright[] =
-   " deflate 1.2.13 Copyright 1995-2022 Jean-loup Gailly and Mark Adler ";
+        " deflate 1.2.13 Copyright 1995-2022 Jean-loup Gailly and Mark Adler ";
 /*
   If you use the zlib library in a product, an acknowledgment is welcome
   in the documentation of your product. If for some reason you cannot
@@ -70,24 +70,38 @@ typedef enum {
     finish_done     /* finish done, accept no more input or output */
 } block_state;
 
-typedef block_state (*compress_func) OF((deflate_state *s, int flush));
+typedef block_state (*compress_func)OF((deflate_state * s, int flush));
 /* Compression function. Returns the block state after the call. */
 
-local int deflateStateCheck      OF((z_streamp strm));
-local void slide_hash     OF((deflate_state *s));
-local void fill_window    OF((deflate_state *s));
-local block_state deflate_stored OF((deflate_state *s, int flush));
-local block_state deflate_fast   OF((deflate_state *s, int flush));
+local int deflateStateCheck OF((z_streamp strm));
+
+local void slide_hash OF((deflate_state * s));
+
+local void fill_window OF((deflate_state * s));
+
+local block_state deflate_stored OF((deflate_state * s, int flush));
+
+local block_state deflate_fast OF((deflate_state * s, int flush));
+
 #ifndef FASTEST
-local block_state deflate_slow   OF((deflate_state *s, int flush));
+
+local block_state deflate_slow OF((deflate_state * s, int flush));
+
 #endif
-local block_state deflate_rle    OF((deflate_state *s, int flush));
-local block_state deflate_huff   OF((deflate_state *s, int flush));
-local void lm_init        OF((deflate_state *s));
-local void putShortMSB    OF((deflate_state *s, uInt b));
-local void flush_pending  OF((z_streamp strm));
-local unsigned read_buf   OF((z_streamp strm, Bytef *buf, unsigned size));
-local uInt longest_match  OF((deflate_state *s, IPos cur_match));
+
+local block_state deflate_rle OF((deflate_state * s, int flush));
+
+local block_state deflate_huff OF((deflate_state * s, int flush));
+
+local void lm_init OF((deflate_state * s));
+
+local void putShortMSB OF((deflate_state * s, uInt b));
+
+local void flush_pending OF((z_streamp strm));
+
+local unsigned read_buf OF((z_streamp strm, Bytef * buf, unsigned size));
+
+local uInt longest_match OF((deflate_state * s, IPos cur_match));
 
 #ifdef ZLIB_DEBUG
 local  void check_match OF((deflate_state *s, IPos start, IPos match,
@@ -112,11 +126,11 @@ local  void check_match OF((deflate_state *s, IPos start, IPos match,
  * found for specific files.
  */
 typedef struct config_s {
-   ush good_length; /* reduce lazy search above this match length */
-   ush max_lazy;    /* do not perform lazy search above this match length */
-   ush nice_length; /* quit search above this match length */
-   ush max_chain;
-   compress_func func;
+    ush good_length; /* reduce lazy search above this match length */
+    ush max_lazy;    /* do not perform lazy search above this match length */
+    ush nice_length; /* quit search above this match length */
+    ush max_chain;
+    compress_func func;
 } config;
 
 #ifdef FASTEST
@@ -127,17 +141,26 @@ local const config configuration_table[2] = {
 #else
 local const config configuration_table[10] = {
 /*      good lazy nice chain */
-/* 0 */ {0,    0,  0,    0, deflate_stored},  /* store only */
-/* 1 */ {4,    4,  8,    4, deflate_fast}, /* max speed, no lazy matches */
-/* 2 */ {4,    5, 16,    8, deflate_fast},
-/* 3 */ {4,    6, 32,   32, deflate_fast},
+/* 0 */ {0,  0,   0,   0,    deflate_stored},  /* store only */
+/* 1 */
+        {4,  4,   8,   4,    deflate_fast}, /* max speed, no lazy matches */
+/* 2 */
+        {4,  5,   16,  8,    deflate_fast},
+/* 3 */
+        {4,  6,   32,  32,   deflate_fast},
 
-/* 4 */ {4,    4, 16,   16, deflate_slow},  /* lazy matches */
-/* 5 */ {8,   16, 32,   32, deflate_slow},
-/* 6 */ {8,   16, 128, 128, deflate_slow},
-/* 7 */ {8,   32, 128, 256, deflate_slow},
-/* 8 */ {32, 128, 258, 1024, deflate_slow},
-/* 9 */ {32, 258, 258, 4096, deflate_slow}}; /* max compression */
+/* 4 */
+        {4,  4,   16,  16,   deflate_slow},  /* lazy matches */
+/* 5 */
+        {8,  16,  32,  32,   deflate_slow},
+/* 6 */
+        {8,  16,  128, 128,  deflate_slow},
+/* 7 */
+        {8,  32,  128, 256,  deflate_slow},
+/* 8 */
+        {32, 128, 258, 1024, deflate_slow},
+/* 9 */
+        {32, 258, 258, 4096, deflate_slow}}; /* max compression */
 #endif
 
 /* Note: the deflate() code requires max_lazy >= MIN_MATCH and max_chain >= 4
@@ -154,7 +177,7 @@ local const config configuration_table[10] = {
  *    characters, so that a running hash key can be computed from the previous
  *    key instead of complete recalculation each time.
  */
-#define UPDATE_HASH(s,h,c) (h = (((h) << s->hash_shift) ^ (c)) & s->hash_mask)
+#define UPDATE_HASH(s, h, c) (h = (((h) << s->hash_shift) ^ (c)) & s->hash_mask)
 
 
 /* ===========================================================================
@@ -195,9 +218,7 @@ local const config configuration_table[10] = {
  * bit values at the expense of memory usage). We slide even when level == 0 to
  * keep the hash table consistent if we switch back to level > 0 later.
  */
-local void slide_hash(s)
-    deflate_state *s;
-{
+local void slide_hash(deflate_state *s) {
     unsigned n, m;
     Posf *p;
     uInt wsize = s->w_size;
@@ -206,14 +227,14 @@ local void slide_hash(s)
     p = &s->head[n];
     do {
         m = *--p;
-        *p = (Pos)(m >= wsize ? m - wsize : NIL);
+        *p = (Pos) (m >= wsize ? m - wsize : NIL);
     } while (--n);
     n = wsize;
 #ifndef FASTEST
     p = &s->prev[n];
     do {
         m = *--p;
-        *p = (Pos)(m >= wsize ? m - wsize : NIL);
+        *p = (Pos) (m >= wsize ? m - wsize : NIL);
         /* If n is not on any hash chain, prev[n] is garbage but
          * its value will never be used.
          */
@@ -222,29 +243,24 @@ local void slide_hash(s)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateInit_(strm, level, version, stream_size)
-    z_streamp strm;
-    int level;
-    const char *version;
-    int stream_size;
-{
+int ZEXPORT deflateInit_(z_streamp strm,
+                         int level,
+                         const char *version,
+                         int stream_size) {
     return deflateInit2_(strm, level, Z_DEFLATED, MAX_WBITS, DEF_MEM_LEVEL,
                          Z_DEFAULT_STRATEGY, version, stream_size);
     /* To do: ignore strm->next_in if we use it as window */
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
-                  version, stream_size)
-    z_streamp strm;
-    int  level;
-    int  method;
-    int  windowBits;
-    int  memLevel;
-    int  strategy;
-    const char *version;
-    int stream_size;
-{
+int ZEXPORT deflateInit2_(z_streamp strm,
+                          int level,
+                          int method,
+                          int windowBits,
+                          int memLevel,
+                          int strategy,
+                          const char *version,
+                          int stream_size) {
     deflate_state *s;
     int wrap = 1;
     static const char my_version[] = ZLIB_VERSION;
@@ -256,15 +272,15 @@ int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
     if (strm == Z_NULL) return Z_STREAM_ERROR;
 
     strm->msg = Z_NULL;
-    if (strm->zalloc == (alloc_func)0) {
+    if (strm->zalloc == (alloc_func) 0) {
 #ifdef Z_SOLO
         return Z_STREAM_ERROR;
 #else
         strm->zalloc = zcalloc;
-        strm->opaque = (voidpf)0;
+        strm->opaque = (voidpf) 0;
 #endif
     }
-    if (strm->zfree == (free_func)0)
+    if (strm->zfree == (free_func) 0)
 #ifdef Z_SOLO
         return Z_STREAM_ERROR;
 #else
@@ -297,24 +313,24 @@ int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
     if (windowBits == 8) windowBits = 9;  /* until 256-byte window bug fixed */
     s = (deflate_state *) ZALLOC(strm, 1, sizeof(deflate_state));
     if (s == Z_NULL) return Z_MEM_ERROR;
-    strm->state = (struct internal_state FAR *)s;
+    strm->state = (struct internal_state FAR *) s;
     s->strm = strm;
     s->status = INIT_STATE;     /* to pass state test in deflateReset() */
 
     s->wrap = wrap;
     s->gzhead = Z_NULL;
-    s->w_bits = (uInt)windowBits;
+    s->w_bits = (uInt) windowBits;
     s->w_size = 1 << s->w_bits;
     s->w_mask = s->w_size - 1;
 
-    s->hash_bits = (uInt)memLevel + 7;
+    s->hash_bits = (uInt) memLevel + 7;
     s->hash_size = 1 << s->hash_bits;
     s->hash_mask = s->hash_size - 1;
-    s->hash_shift =  ((s->hash_bits + MIN_MATCH-1) / MIN_MATCH);
+    s->hash_shift = ((s->hash_bits + MIN_MATCH - 1) / MIN_MATCH);
 
-    s->window = (Bytef *) ZALLOC(strm, s->w_size, 2*sizeof(Byte));
-    s->prev   = (Posf *)  ZALLOC(strm, s->w_size, sizeof(Pos));
-    s->head   = (Posf *)  ZALLOC(strm, s->hash_size, sizeof(Pos));
+    s->window = (Bytef *) ZALLOC(strm, s->w_size, 2 * sizeof(Byte));
+    s->prev = (Posf *) ZALLOC(strm, s->w_size, sizeof(Pos));
+    s->head = (Posf *) ZALLOC(strm, s->hash_size, sizeof(Pos));
 
     s->high_water = 0;      /* nothing written to s->window yet */
 
@@ -360,13 +376,13 @@ int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
      */
 
     s->pending_buf = (uchf *) ZALLOC(strm, s->lit_bufsize, 4);
-    s->pending_buf_size = (ulg)s->lit_bufsize * 4;
+    s->pending_buf_size = (ulg) s->lit_bufsize * 4;
 
     if (s->window == Z_NULL || s->prev == Z_NULL || s->head == Z_NULL ||
         s->pending_buf == Z_NULL) {
         s->status = FINISH_STATE;
         strm->msg = ERR_MSG(Z_MEM_ERROR);
-        deflateEnd (strm);
+        deflateEnd(strm);
         return Z_MEM_ERROR;
     }
     s->sym_buf = s->pending_buf + s->lit_bufsize;
@@ -378,7 +394,7 @@ int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
 
     s->level = level;
     s->strategy = strategy;
-    s->method = (Byte)method;
+    s->method = (Byte) method;
 
     return deflateReset(strm);
 }
@@ -386,18 +402,16 @@ int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
 /* =========================================================================
  * Check for a valid deflate stream state. Return 0 if ok, 1 if not.
  */
-local int deflateStateCheck(strm)
-    z_streamp strm;
-{
+local int deflateStateCheck(z_streamp strm) {
     deflate_state *s;
     if (strm == Z_NULL ||
-        strm->zalloc == (alloc_func)0 || strm->zfree == (free_func)0)
+        strm->zalloc == (alloc_func) 0 || strm->zfree == (free_func) 0)
         return 1;
     s = strm->state;
     if (s == Z_NULL || s->strm != strm || (s->status != INIT_STATE &&
-#ifdef GZIP
+                                           #ifdef GZIP
                                            s->status != GZIP_STATE &&
-#endif
+                                           #endif
                                            s->status != EXTRA_STATE &&
                                            s->status != NAME_STATE &&
                                            s->status != COMMENT_STATE &&
@@ -409,11 +423,9 @@ local int deflateStateCheck(strm)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateSetDictionary(strm, dictionary, dictLength)
-    z_streamp strm;
-    const Bytef *dictionary;
-    uInt  dictLength;
-{
+int ZEXPORT deflateSetDictionary(z_streamp strm,
+                                 const Bytef *dictionary,
+                                 uInt dictLength) {
     deflate_state *s;
     uInt str, n;
     int wrap;
@@ -448,28 +460,28 @@ int ZEXPORT deflateSetDictionary(strm, dictionary, dictLength)
     avail = strm->avail_in;
     next = strm->next_in;
     strm->avail_in = dictLength;
-    strm->next_in = (z_const Bytef *)dictionary;
+    strm->next_in = (z_const Bytef *) dictionary;
     fill_window(s);
     while (s->lookahead >= MIN_MATCH) {
         str = s->strstart;
-        n = s->lookahead - (MIN_MATCH-1);
+        n = s->lookahead - (MIN_MATCH - 1);
         do {
-            UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH-1]);
+            UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH - 1]);
 #ifndef FASTEST
             s->prev[str & s->w_mask] = s->head[s->ins_h];
 #endif
-            s->head[s->ins_h] = (Pos)str;
+            s->head[s->ins_h] = (Pos) str;
             str++;
         } while (--n);
         s->strstart = str;
-        s->lookahead = MIN_MATCH-1;
+        s->lookahead = MIN_MATCH - 1;
         fill_window(s);
     }
     s->strstart += s->lookahead;
-    s->block_start = (long)s->strstart;
+    s->block_start = (long) s->strstart;
     s->insert = s->lookahead;
     s->lookahead = 0;
-    s->match_length = s->prev_length = MIN_MATCH-1;
+    s->match_length = s->prev_length = MIN_MATCH - 1;
     s->match_available = 0;
     strm->next_in = next;
     strm->avail_in = avail;
@@ -478,11 +490,9 @@ int ZEXPORT deflateSetDictionary(strm, dictionary, dictLength)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateGetDictionary(strm, dictionary, dictLength)
-    z_streamp strm;
-    Bytef *dictionary;
-    uInt  *dictLength;
-{
+int ZEXPORT deflateGetDictionary(z_streamp strm,
+                                 Bytef *dictionary,
+                                 uInt *dictLength) {
     deflate_state *s;
     uInt len;
 
@@ -500,9 +510,7 @@ int ZEXPORT deflateGetDictionary(strm, dictionary, dictLength)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateResetKeep(strm)
-    z_streamp strm;
-{
+int ZEXPORT deflateResetKeep(z_streamp strm) {
     deflate_state *s;
 
     if (deflateStateCheck(strm)) {
@@ -513,7 +521,7 @@ int ZEXPORT deflateResetKeep(strm)
     strm->msg = Z_NULL; /* use zfree if we ever allocate msg dynamically */
     strm->data_type = Z_UNKNOWN;
 
-    s = (deflate_state *)strm->state;
+    s = (deflate_state *) strm->state;
     s->pending = 0;
     s->pending_out = s->pending_buf;
 
@@ -522,14 +530,14 @@ int ZEXPORT deflateResetKeep(strm)
     }
     s->status =
 #ifdef GZIP
-        s->wrap == 2 ? GZIP_STATE :
+s->wrap == 2 ? GZIP_STATE :
 #endif
-        INIT_STATE;
+INIT_STATE;
     strm->adler =
 #ifdef GZIP
-        s->wrap == 2 ? crc32(0L, Z_NULL, 0) :
+s->wrap == 2 ? crc32(0L, Z_NULL, 0) :
 #endif
-        adler32(0L, Z_NULL, 0);
+adler32(0L, Z_NULL, 0);
     s->last_flush = -2;
 
     _tr_init(s);
@@ -538,9 +546,7 @@ int ZEXPORT deflateResetKeep(strm)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateReset(strm)
-    z_streamp strm;
-{
+int ZEXPORT deflateReset(z_streamp strm) {
     int ret;
 
     ret = deflateResetKeep(strm);
@@ -550,10 +556,8 @@ int ZEXPORT deflateReset(strm)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateSetHeader(strm, head)
-    z_streamp strm;
-    gz_headerp head;
-{
+int ZEXPORT deflateSetHeader(z_streamp strm,
+                             gz_headerp head) {
     if (deflateStateCheck(strm) || strm->state->wrap != 2)
         return Z_STREAM_ERROR;
     strm->state->gzhead = head;
@@ -561,11 +565,10 @@ int ZEXPORT deflateSetHeader(strm, head)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflatePending(strm, pending, bits)
-    unsigned *pending;
-    int *bits;
-    z_streamp strm;
-{
+int ZEXPORT deflatePending(z_streamp strm,
+                           unsigned *pending,
+                           int *bits) {
+
     if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
     if (pending != Z_NULL)
         *pending = strm->state->pending;
@@ -575,11 +578,9 @@ int ZEXPORT deflatePending(strm, pending, bits)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflatePrime(strm, bits, value)
-    z_streamp strm;
-    int bits;
-    int value;
-{
+int ZEXPORT deflatePrime(z_streamp strm,
+                         int bits,
+                         int value) {
     deflate_state *s;
     int put;
 
@@ -592,7 +593,7 @@ int ZEXPORT deflatePrime(strm, bits, value)
         put = Buf_size - s->bi_valid;
         if (put > bits)
             put = bits;
-        s->bi_buf |= (ush)((value & ((1 << put) - 1)) << s->bi_valid);
+        s->bi_buf |= (ush) ((value & ((1 << put) - 1)) << s->bi_valid);
         s->bi_valid += put;
         _tr_flush_bits(s);
         value >>= put;
@@ -602,11 +603,9 @@ int ZEXPORT deflatePrime(strm, bits, value)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateParams(strm, level, strategy)
-    z_streamp strm;
-    int level;
-    int strategy;
-{
+int ZEXPORT deflateParams(z_streamp strm,
+                          int level,
+                          int strategy) {
     deflate_state *s;
     compress_func func;
 
@@ -641,9 +640,9 @@ int ZEXPORT deflateParams(strm, level, strategy)
             s->matches = 0;
         }
         s->level = level;
-        s->max_lazy_match   = configuration_table[level].max_lazy;
-        s->good_match       = configuration_table[level].good_length;
-        s->nice_match       = configuration_table[level].nice_length;
+        s->max_lazy_match = configuration_table[level].max_lazy;
+        s->good_match = configuration_table[level].good_length;
+        s->nice_match = configuration_table[level].nice_length;
         s->max_chain_length = configuration_table[level].max_chain;
     }
     s->strategy = strategy;
@@ -651,21 +650,19 @@ int ZEXPORT deflateParams(strm, level, strategy)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateTune(strm, good_length, max_lazy, nice_length, max_chain)
-    z_streamp strm;
-    int good_length;
-    int max_lazy;
-    int nice_length;
-    int max_chain;
-{
+int ZEXPORT deflateTune(z_streamp strm,
+                        int good_length,
+                        int max_lazy,
+                        int nice_length,
+                        int max_chain) {
     deflate_state *s;
 
     if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
     s = strm->state;
-    s->good_match = (uInt)good_length;
-    s->max_lazy_match = (uInt)max_lazy;
+    s->good_match = (uInt) good_length;
+    s->max_lazy_match = (uInt) max_lazy;
     s->nice_match = nice_length;
-    s->max_chain_length = (uInt)max_chain;
+    s->max_chain_length = (uInt) max_chain;
     return Z_OK;
 }
 
@@ -693,10 +690,8 @@ int ZEXPORT deflateTune(strm, good_length, max_lazy, nice_length, max_chain)
  *
  * Shifts are used to approximate divisions, for speed.
  */
-uLong ZEXPORT deflateBound(strm, sourceLen)
-    z_streamp strm;
-    uLong sourceLen;
-{
+uLong ZEXPORT deflateBound(z_streamp strm,
+                           uLong sourceLen) {
     deflate_state *s;
     uLong fixedlen, storelen, wraplen;
 
@@ -718,36 +713,36 @@ uLong ZEXPORT deflateBound(strm, sourceLen)
     /* compute wrapper length */
     s = strm->state;
     switch (s->wrap) {
-    case 0:                                 /* raw deflate */
-        wraplen = 0;
-        break;
-    case 1:                                 /* zlib wrapper */
-        wraplen = 6 + (s->strstart ? 4 : 0);
-        break;
+        case 0:                                 /* raw deflate */
+            wraplen = 0;
+            break;
+        case 1:                                 /* zlib wrapper */
+            wraplen = 6 + (s->strstart ? 4 : 0);
+            break;
 #ifdef GZIP
-    case 2:                                 /* gzip wrapper */
-        wraplen = 18;
-        if (s->gzhead != Z_NULL) {          /* user-supplied gzip header */
-            Bytef *str;
-            if (s->gzhead->extra != Z_NULL)
-                wraplen += 2 + s->gzhead->extra_len;
-            str = s->gzhead->name;
-            if (str != Z_NULL)
-                do {
-                    wraplen++;
-                } while (*str++);
-            str = s->gzhead->comment;
-            if (str != Z_NULL)
-                do {
-                    wraplen++;
-                } while (*str++);
-            if (s->gzhead->hcrc)
-                wraplen += 2;
-        }
-        break;
+        case 2:                                 /* gzip wrapper */
+            wraplen = 18;
+            if (s->gzhead != Z_NULL) {          /* user-supplied gzip header */
+                Bytef *str;
+                if (s->gzhead->extra != Z_NULL)
+                    wraplen += 2 + s->gzhead->extra_len;
+                str = s->gzhead->name;
+                if (str != Z_NULL)
+                    do {
+                        wraplen++;
+                    } while (*str++);
+                str = s->gzhead->comment;
+                if (str != Z_NULL)
+                    do {
+                        wraplen++;
+                    } while (*str++);
+                if (s->gzhead->hcrc)
+                    wraplen += 2;
+            }
+            break;
 #endif
-    default:                                /* for compiler happiness */
-        wraplen = 6;
+        default:                                /* for compiler happiness */
+            wraplen = 6;
     }
 
     /* if not default parameters, return one of the conservative bounds */
@@ -765,12 +760,10 @@ uLong ZEXPORT deflateBound(strm, sourceLen)
  * IN assertion: the stream state is correct and there is enough room in
  * pending_buf.
  */
-local void putShortMSB(s, b)
-    deflate_state *s;
-    uInt b;
-{
-    put_byte(s, (Byte)(b >> 8));
-    put_byte(s, (Byte)(b & 0xff));
+local void putShortMSB(deflate_state *s,
+                       uInt b) {
+    put_byte(s, (Byte) (b >> 8));
+    put_byte(s, (Byte) (b & 0xff));
 }
 
 /* =========================================================================
@@ -779,9 +772,7 @@ local void putShortMSB(s, b)
  * applications may wish to modify it to avoid allocating a large
  * strm->next_out buffer and copying into it. (See also read_buf()).
  */
-local void flush_pending(strm)
-    z_streamp strm;
-{
+local void flush_pending(z_streamp strm) {
     unsigned len;
     deflate_state *s = strm->state;
 
@@ -791,11 +782,11 @@ local void flush_pending(strm)
     if (len == 0) return;
 
     zmemcpy(strm->next_out, s->pending_out, len);
-    strm->next_out  += len;
-    s->pending_out  += len;
+    strm->next_out += len;
+    s->pending_out += len;
     strm->total_out += len;
     strm->avail_out -= len;
-    s->pending      -= len;
+    s->pending -= len;
     if (s->pending == 0) {
         s->pending_out = s->pending_buf;
     }
@@ -812,10 +803,8 @@ local void flush_pending(strm)
     } while (0)
 
 /* ========================================================================= */
-int ZEXPORT deflate(strm, flush)
-    z_streamp strm;
-    int flush;
-{
+int ZEXPORT deflate(z_streamp strm,
+                    int flush) {
     int old_flush; /* value of flush param for previous deflate call */
     deflate_state *s;
 
@@ -848,10 +837,10 @@ int ZEXPORT deflate(strm, flush)
             return Z_OK;
         }
 
-    /* Make sure there is something to do and avoid duplicate consecutive
-     * flushes. For repeated and useless calls with Z_FINISH, we keep
-     * returning Z_STREAM_END instead of Z_BUF_ERROR.
-     */
+        /* Make sure there is something to do and avoid duplicate consecutive
+         * flushes. For repeated and useless calls with Z_FINISH, we keep
+         * returning Z_STREAM_END instead of Z_BUF_ERROR.
+         */
     } else if (strm->avail_in == 0 && RANK(flush) <= RANK(old_flush) &&
                flush != Z_FINISH) {
         ERR_RETURN(strm, Z_BUF_ERROR);
@@ -886,8 +875,8 @@ int ZEXPORT deflate(strm, flush)
 
         /* Save the adler32 of the preset dictionary: */
         if (s->strstart != 0) {
-            putShortMSB(s, (uInt)(strm->adler >> 16));
-            putShortMSB(s, (uInt)(strm->adler & 0xffff));
+            putShortMSB(s, (uInt) (strm->adler >> 16));
+            putShortMSB(s, (uInt) (strm->adler & 0xffff));
         }
         strm->adler = adler32(0L, Z_NULL, 0);
         s->status = BUSY_STATE;
@@ -913,8 +902,8 @@ int ZEXPORT deflate(strm, flush)
             put_byte(s, 0);
             put_byte(s, 0);
             put_byte(s, s->level == 9 ? 2 :
-                     (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2 ?
-                      4 : 0));
+                        (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2 ?
+                         4 : 0));
             put_byte(s, OS_CODE);
             s->status = BUSY_STATE;
 
@@ -924,21 +913,20 @@ int ZEXPORT deflate(strm, flush)
                 s->last_flush = -1;
                 return Z_OK;
             }
-        }
-        else {
+        } else {
             put_byte(s, (s->gzhead->text ? 1 : 0) +
-                     (s->gzhead->hcrc ? 2 : 0) +
-                     (s->gzhead->extra == Z_NULL ? 0 : 4) +
-                     (s->gzhead->name == Z_NULL ? 0 : 8) +
-                     (s->gzhead->comment == Z_NULL ? 0 : 16)
-                     );
-            put_byte(s, (Byte)(s->gzhead->time & 0xff));
-            put_byte(s, (Byte)((s->gzhead->time >> 8) & 0xff));
-            put_byte(s, (Byte)((s->gzhead->time >> 16) & 0xff));
-            put_byte(s, (Byte)((s->gzhead->time >> 24) & 0xff));
+                        (s->gzhead->hcrc ? 2 : 0) +
+                        (s->gzhead->extra == Z_NULL ? 0 : 4) +
+                        (s->gzhead->name == Z_NULL ? 0 : 8) +
+                        (s->gzhead->comment == Z_NULL ? 0 : 16)
+            );
+            put_byte(s, (Byte) (s->gzhead->time & 0xff));
+            put_byte(s, (Byte) ((s->gzhead->time >> 8) & 0xff));
+            put_byte(s, (Byte) ((s->gzhead->time >> 16) & 0xff));
+            put_byte(s, (Byte) ((s->gzhead->time >> 24) & 0xff));
             put_byte(s, s->level == 9 ? 2 :
-                     (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2 ?
-                      4 : 0));
+                        (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2 ?
+                         4 : 0));
             put_byte(s, s->gzhead->os & 0xff);
             if (s->gzhead->extra != Z_NULL) {
                 put_byte(s, s->gzhead->extra_len & 0xff);
@@ -1030,8 +1018,8 @@ int ZEXPORT deflate(strm, flush)
                     return Z_OK;
                 }
             }
-            put_byte(s, (Byte)(strm->adler & 0xff));
-            put_byte(s, (Byte)((strm->adler >> 8) & 0xff));
+            put_byte(s, (Byte) (strm->adler & 0xff));
+            put_byte(s, (Byte) ((strm->adler >> 8) & 0xff));
             strm->adler = crc32(0L, Z_NULL, 0);
         }
         s->status = BUSY_STATE;
@@ -1076,7 +1064,7 @@ int ZEXPORT deflate(strm, flush)
             if (flush == Z_PARTIAL_FLUSH) {
                 _tr_align(s);
             } else if (flush != Z_BLOCK) { /* FULL_FLUSH or SYNC_FLUSH */
-                _tr_stored_block(s, (char*)0, 0L, 0);
+                _tr_stored_block(s, (char *) 0, 0L, 0);
                 /* For a full flush, this empty block will be recognized
                  * as a special marker by inflate_sync().
                  */
@@ -1091,8 +1079,8 @@ int ZEXPORT deflate(strm, flush)
             }
             flush_pending(strm);
             if (strm->avail_out == 0) {
-              s->last_flush = -1; /* avoid BUF_ERROR at next call, see above */
-              return Z_OK;
+                s->last_flush = -1; /* avoid BUF_ERROR at next call, see above */
+                return Z_OK;
             }
         }
     }
@@ -1103,20 +1091,19 @@ int ZEXPORT deflate(strm, flush)
     /* Write the trailer */
 #ifdef GZIP
     if (s->wrap == 2) {
-        put_byte(s, (Byte)(strm->adler & 0xff));
-        put_byte(s, (Byte)((strm->adler >> 8) & 0xff));
-        put_byte(s, (Byte)((strm->adler >> 16) & 0xff));
-        put_byte(s, (Byte)((strm->adler >> 24) & 0xff));
-        put_byte(s, (Byte)(strm->total_in & 0xff));
-        put_byte(s, (Byte)((strm->total_in >> 8) & 0xff));
-        put_byte(s, (Byte)((strm->total_in >> 16) & 0xff));
-        put_byte(s, (Byte)((strm->total_in >> 24) & 0xff));
-    }
-    else
+        put_byte(s, (Byte) (strm->adler & 0xff));
+        put_byte(s, (Byte) ((strm->adler >> 8) & 0xff));
+        put_byte(s, (Byte) ((strm->adler >> 16) & 0xff));
+        put_byte(s, (Byte) ((strm->adler >> 24) & 0xff));
+        put_byte(s, (Byte) (strm->total_in & 0xff));
+        put_byte(s, (Byte) ((strm->total_in >> 8) & 0xff));
+        put_byte(s, (Byte) ((strm->total_in >> 16) & 0xff));
+        put_byte(s, (Byte) ((strm->total_in >> 24) & 0xff));
+    } else
 #endif
     {
-        putShortMSB(s, (uInt)(strm->adler >> 16));
-        putShortMSB(s, (uInt)(strm->adler & 0xffff));
+        putShortMSB(s, (uInt) (strm->adler >> 16));
+        putShortMSB(s, (uInt) (strm->adler & 0xffff));
     }
     flush_pending(strm);
     /* If avail_out is zero, the application will call deflate again
@@ -1127,9 +1114,7 @@ int ZEXPORT deflate(strm, flush)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateEnd(strm)
-    z_streamp strm;
-{
+int ZEXPORT deflateEnd(z_streamp strm) {
     int status;
 
     if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
@@ -1153,10 +1138,8 @@ int ZEXPORT deflateEnd(strm)
  * To simplify the source, this is not supported for 16-bit MSDOS (which
  * doesn't have enough memory anyway to duplicate compression states).
  */
-int ZEXPORT deflateCopy(dest, source)
-    z_streamp dest;
-    z_streamp source;
-{
+int ZEXPORT deflateCopy(z_streamp dest,
+                        z_streamp source) {
 #ifdef MAXSEG_64K
     return Z_STREAM_ERROR;
 #else
@@ -1170,29 +1153,29 @@ int ZEXPORT deflateCopy(dest, source)
 
     ss = source->state;
 
-    zmemcpy((voidpf)dest, (voidpf)source, sizeof(z_stream));
+    zmemcpy((voidpf) dest, (voidpf) source, sizeof(z_stream));
 
     ds = (deflate_state *) ZALLOC(dest, 1, sizeof(deflate_state));
     if (ds == Z_NULL) return Z_MEM_ERROR;
     dest->state = (struct internal_state FAR *) ds;
-    zmemcpy((voidpf)ds, (voidpf)ss, sizeof(deflate_state));
+    zmemcpy((voidpf) ds, (voidpf) ss, sizeof(deflate_state));
     ds->strm = dest;
 
-    ds->window = (Bytef *) ZALLOC(dest, ds->w_size, 2*sizeof(Byte));
-    ds->prev   = (Posf *)  ZALLOC(dest, ds->w_size, sizeof(Pos));
-    ds->head   = (Posf *)  ZALLOC(dest, ds->hash_size, sizeof(Pos));
+    ds->window = (Bytef *) ZALLOC(dest, ds->w_size, 2 * sizeof(Byte));
+    ds->prev = (Posf *) ZALLOC(dest, ds->w_size, sizeof(Pos));
+    ds->head = (Posf *) ZALLOC(dest, ds->hash_size, sizeof(Pos));
     ds->pending_buf = (uchf *) ZALLOC(dest, ds->lit_bufsize, 4);
 
     if (ds->window == Z_NULL || ds->prev == Z_NULL || ds->head == Z_NULL ||
         ds->pending_buf == Z_NULL) {
-        deflateEnd (dest);
+        deflateEnd(dest);
         return Z_MEM_ERROR;
     }
     /* following zmemcpy do not work for 16-bit MSDOS */
     zmemcpy(ds->window, ss->window, ds->w_size * 2 * sizeof(Byte));
-    zmemcpy((voidpf)ds->prev, (voidpf)ss->prev, ds->w_size * sizeof(Pos));
-    zmemcpy((voidpf)ds->head, (voidpf)ss->head, ds->hash_size * sizeof(Pos));
-    zmemcpy(ds->pending_buf, ss->pending_buf, (uInt)ds->pending_buf_size);
+    zmemcpy((voidpf) ds->prev, (voidpf) ss->prev, ds->w_size * sizeof(Pos));
+    zmemcpy((voidpf) ds->head, (voidpf) ss->head, ds->hash_size * sizeof(Pos));
+    zmemcpy(ds->pending_buf, ss->pending_buf, (uInt) ds->pending_buf_size);
 
     ds->pending_out = ds->pending_buf + (ss->pending_out - ss->pending_buf);
     ds->sym_buf = ds->pending_buf + ds->lit_bufsize;
@@ -1212,17 +1195,15 @@ int ZEXPORT deflateCopy(dest, source)
  * allocating a large strm->next_in buffer and copying from it.
  * (See also flush_pending()).
  */
-local unsigned read_buf(strm, buf, size)
-    z_streamp strm;
-    Bytef *buf;
-    unsigned size;
-{
+local unsigned read_buf(z_streamp strm,
+                        Bytef *buf,
+                        unsigned size) {
     unsigned len = strm->avail_in;
 
     if (len > size) len = size;
     if (len == 0) return 0;
 
-    strm->avail_in  -= len;
+    strm->avail_in -= len;
 
     zmemcpy(buf, strm->next_in, len);
     if (strm->state->wrap == 1) {
@@ -1233,7 +1214,7 @@ local unsigned read_buf(strm, buf, size)
         strm->adler = crc32(strm->adler, buf, len);
     }
 #endif
-    strm->next_in  += len;
+    strm->next_in += len;
     strm->total_in += len;
 
     return len;
@@ -1242,25 +1223,23 @@ local unsigned read_buf(strm, buf, size)
 /* ===========================================================================
  * Initialize the "longest match" routines for a new zlib stream
  */
-local void lm_init(s)
-    deflate_state *s;
-{
-    s->window_size = (ulg)2L*s->w_size;
+local void lm_init(deflate_state *s) {
+    s->window_size = (ulg) 2L * s->w_size;
 
     CLEAR_HASH(s);
 
     /* Set the default configuration parameters:
      */
-    s->max_lazy_match   = configuration_table[s->level].max_lazy;
-    s->good_match       = configuration_table[s->level].good_length;
-    s->nice_match       = configuration_table[s->level].nice_length;
+    s->max_lazy_match = configuration_table[s->level].max_lazy;
+    s->good_match = configuration_table[s->level].good_length;
+    s->nice_match = configuration_table[s->level].nice_length;
     s->max_chain_length = configuration_table[s->level].max_chain;
 
     s->strstart = 0;
     s->block_start = 0L;
     s->lookahead = 0;
     s->insert = 0;
-    s->match_length = s->prev_length = MIN_MATCH-1;
+    s->match_length = s->prev_length = MIN_MATCH - 1;
     s->match_available = 0;
     s->ins_h = 0;
 }
@@ -1275,18 +1254,17 @@ local void lm_init(s)
  *   string (strstart) and its distance is <= MAX_DIST, and prev_length >= 1
  * OUT assertion: the match length is not greater than s->lookahead.
  */
-local uInt longest_match(s, cur_match)
-    deflate_state *s;
-    IPos cur_match;                             /* current match */
+local uInt longest_match(deflate_state *s,
+                         IPos cur_match)     /* current match */
 {
     unsigned chain_length = s->max_chain_length;/* max hash chain length */
     register Bytef *scan = s->window + s->strstart; /* current string */
     register Bytef *match;                      /* matched string */
     register int len;                           /* length of current match */
-    int best_len = (int)s->prev_length;         /* best match length so far */
+    int best_len = (int) s->prev_length;         /* best match length so far */
     int nice_match = s->nice_match;             /* stop if match long enough */
-    IPos limit = s->strstart > (IPos)MAX_DIST(s) ?
-        s->strstart - (IPos)MAX_DIST(s) : NIL;
+    IPos limit = s->strstart > (IPos) MAX_DIST(s) ?
+                 s->strstart - (IPos) MAX_DIST(s) : NIL;
     /* Stop when cur_match becomes <= limit. To simplify the code,
      * we prevent matches with the string of window index 0.
      */
@@ -1302,8 +1280,8 @@ local uInt longest_match(s, cur_match)
     register ush scan_end   = *(ushf*)(scan + best_len - 1);
 #else
     register Bytef *strend = s->window + s->strstart + MAX_MATCH;
-    register Byte scan_end1  = scan[best_len - 1];
-    register Byte scan_end   = scan[best_len];
+    register Byte scan_end1 = scan[best_len - 1];
+    register Byte scan_end = scan[best_len];
 #endif
 
     /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
@@ -1318,9 +1296,9 @@ local uInt longest_match(s, cur_match)
     /* Do not look for matches beyond the end of the input. This is necessary
      * to make deflate deterministic.
      */
-    if ((uInt)nice_match > s->lookahead) nice_match = (int)s->lookahead;
+    if ((uInt) nice_match > s->lookahead) nice_match = (int) s->lookahead;
 
-    Assert((ulg)s->strstart <= s->window_size - MIN_LOOKAHEAD,
+    Assert((ulg) s->strstart <= s->window_size - MIN_LOOKAHEAD,
            "need lookahead");
 
     do {
@@ -1371,10 +1349,11 @@ local uInt longest_match(s, cur_match)
 
 #else /* UNALIGNED_OK */
 
-        if (match[best_len]     != scan_end  ||
+        if (match[best_len] != scan_end ||
             match[best_len - 1] != scan_end1 ||
-            *match              != *scan     ||
-            *++match            != scan[1])      continue;
+            *match != *scan ||
+            *++match != scan[1])
+            continue;
 
         /* The check at best_len - 1 can be removed because it will be made
          * again later. (This heuristic is not always a win.)
@@ -1395,10 +1374,10 @@ local uInt longest_match(s, cur_match)
                  *++scan == *++match && *++scan == *++match &&
                  scan < strend);
 
-        Assert(scan <= s->window + (unsigned)(s->window_size - 1),
+        Assert(scan <= s->window + (unsigned) (s->window_size - 1),
                "wild scan");
 
-        len = MAX_MATCH - (int)(strend - scan);
+        len = MAX_MATCH - (int) (strend - scan);
         scan = strend - MAX_MATCH;
 
 #endif /* UNALIGNED_OK */
@@ -1410,14 +1389,14 @@ local uInt longest_match(s, cur_match)
 #ifdef UNALIGNED_OK
             scan_end = *(ushf*)(scan + best_len - 1);
 #else
-            scan_end1  = scan[best_len - 1];
-            scan_end   = scan[best_len];
+            scan_end1 = scan[best_len - 1];
+            scan_end = scan[best_len];
 #endif
         }
     } while ((cur_match = prev[cur_match & wmask]) > limit
              && --chain_length != 0);
 
-    if ((uInt)best_len <= s->lookahead) return (uInt)best_len;
+    if ((uInt) best_len <= s->lookahead) return (uInt) best_len;
     return s->lookahead;
 }
 
@@ -1524,9 +1503,7 @@ local void check_match(s, start, match, length)
  *    performed for at least two bytes (required for the zip translate_eol
  *    option -- not supported here).
  */
-local void fill_window(s)
-    deflate_state *s;
-{
+local void fill_window(deflate_state *s) {
     unsigned n;
     unsigned more;    /* Amount of free space at the end of the window. */
     uInt wsize = s->w_size;
@@ -1534,14 +1511,14 @@ local void fill_window(s)
     Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
 
     do {
-        more = (unsigned)(s->window_size -(ulg)s->lookahead -(ulg)s->strstart);
+        more = (unsigned) (s->window_size - (ulg) s->lookahead - (ulg) s->strstart);
 
         /* Deal with !@#$% 64K limit: */
         if (sizeof(int) <= 2) {
             if (more == 0 && s->strstart == 0 && s->lookahead == 0) {
                 more = wsize;
 
-            } else if (more == (unsigned)(-1)) {
+            } else if (more == (unsigned) (-1)) {
                 /* Very unlikely, but possible on 16 bit machine if
                  * strstart == 0 && lookahead == 1 (input done a byte at time)
                  */
@@ -1554,9 +1531,9 @@ local void fill_window(s)
          */
         if (s->strstart >= wsize + MAX_DIST(s)) {
 
-            zmemcpy(s->window, s->window + wsize, (unsigned)wsize - more);
+            zmemcpy(s->window, s->window + wsize, (unsigned) wsize - more);
             s->match_start -= wsize;
-            s->strstart    -= wsize; /* we now have strstart >= MAX_DIST */
+            s->strstart -= wsize; /* we now have strstart >= MAX_DIST */
             s->block_start -= (long) wsize;
             if (s->insert > s->strstart)
                 s->insert = s->strstart;
@@ -1590,11 +1567,11 @@ local void fill_window(s)
             Call UPDATE_HASH() MIN_MATCH-3 more times
 #endif
             while (s->insert) {
-                UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH-1]);
+                UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH - 1]);
 #ifndef FASTEST
                 s->prev[str & s->w_mask] = s->head[s->ins_h];
 #endif
-                s->head[s->ins_h] = (Pos)str;
+                s->head[s->ins_h] = (Pos) str;
                 str++;
                 s->insert--;
                 if (s->lookahead + s->insert < MIN_MATCH)
@@ -1615,7 +1592,7 @@ local void fill_window(s)
      * routines allow scanning to strstart + MAX_MATCH, ignoring lookahead.
      */
     if (s->high_water < s->window_size) {
-        ulg curr = s->strstart + (ulg)(s->lookahead);
+        ulg curr = s->strstart + (ulg) (s->lookahead);
         ulg init;
 
         if (s->high_water < curr) {
@@ -1625,23 +1602,22 @@ local void fill_window(s)
             init = s->window_size - curr;
             if (init > WIN_INIT)
                 init = WIN_INIT;
-            zmemzero(s->window + curr, (unsigned)init);
+            zmemzero(s->window + curr, (unsigned) init);
             s->high_water = curr + init;
-        }
-        else if (s->high_water < (ulg)curr + WIN_INIT) {
+        } else if (s->high_water < (ulg) curr + WIN_INIT) {
             /* High water mark at or above current data, but below current data
              * plus WIN_INIT -- zero out to current data plus WIN_INIT, or up
              * to end of window, whichever is less.
              */
-            init = (ulg)curr + WIN_INIT - s->high_water;
+            init = (ulg) curr + WIN_INIT - s->high_water;
             if (init > s->window_size - s->high_water)
                 init = s->window_size - s->high_water;
-            zmemzero(s->window + s->high_water, (unsigned)init);
+            zmemzero(s->window + s->high_water, (unsigned) init);
             s->high_water += init;
         }
     }
 
-    Assert((ulg)s->strstart <= s->window_size - MIN_LOOKAHEAD,
+    Assert((ulg) s->strstart <= s->window_size - MIN_LOOKAHEAD,
            "not enough room for search");
 }
 
@@ -1687,10 +1663,8 @@ local void fill_window(s)
  * copied. It is most efficient with large input and output buffers, which
  * maximizes the opportunities to have a single copy from next_in to next_out.
  */
-local block_state deflate_stored(s, flush)
-    deflate_state *s;
-    int flush;
-{
+local block_state deflate_stored(deflate_state *s,
+                                 int flush) {
     /* Smallest worthy block size when not flushing or finishing. By default
      * this is 32K. This can be as small as 507 bytes for memLevel == 1. For
      * large input and output buffers, the stored block size will be larger.
@@ -1712,10 +1686,10 @@ local block_state deflate_stored(s, flush)
         have = (s->bi_valid + 42) >> 3;         /* number of header bytes */
         if (s->strm->avail_out < have)          /* need room for header */
             break;
-            /* maximum stored block length that will fit in avail_out: */
+        /* maximum stored block length that will fit in avail_out: */
         have = s->strm->avail_out - have;
         left = s->strstart - s->block_start;    /* bytes left in window */
-        if (len > (ulg)left + s->strm->avail_in)
+        if (len > (ulg) left + s->strm->avail_in)
             len = left + s->strm->avail_in;     /* limit len to the input */
         if (len > have)
             len = have;                         /* limit len to the output */
@@ -1734,7 +1708,7 @@ local block_state deflate_stored(s, flush)
          * including any pending bits. This also updates the debugging counts.
          */
         last = flush == Z_FINISH && len == left + s->strm->avail_in ? 1 : 0;
-        _tr_stored_block(s, (char *)0, 0L, last);
+        _tr_stored_block(s, (char *) 0, 0L, last);
 
         /* Replace the lengths in the dummy stored block with len. */
         s->pending_buf[s->pending - 4] = len;
@@ -1790,8 +1764,7 @@ local block_state deflate_stored(s, flush)
             zmemcpy(s->window, s->strm->next_in - s->w_size, s->w_size);
             s->strstart = s->w_size;
             s->insert = s->strstart;
-        }
-        else {
+        } else {
             if (s->window_size - s->strstart <= used) {
                 /* Slide the window down. */
                 s->strstart -= s->w_size;
@@ -1816,12 +1789,12 @@ local block_state deflate_stored(s, flush)
 
     /* If flushing and all input has been consumed, then done. */
     if (flush != Z_NO_FLUSH && flush != Z_FINISH &&
-        s->strm->avail_in == 0 && (long)s->strstart == s->block_start)
+        s->strm->avail_in == 0 && (long) s->strstart == s->block_start)
         return block_done;
 
     /* Fill the window with any remaining input. */
     have = s->window_size - s->strstart;
-    if (s->strm->avail_in > have && s->block_start >= (long)s->w_size) {
+    if (s->strm->avail_in > have && s->block_start >= (long) s->w_size) {
         /* Slide the window down. */
         s->block_start -= s->w_size;
         s->strstart -= s->w_size;
@@ -1848,7 +1821,7 @@ local block_state deflate_stored(s, flush)
      * room for the remaining input as a stored block in the pending buffer.
      */
     have = (s->bi_valid + 42) >> 3;         /* number of header bytes */
-        /* maximum stored block length that will fit in pending: */
+    /* maximum stored block length that will fit in pending: */
     have = MIN(s->pending_buf_size - have, MAX_STORED);
     min_block = MIN(have, s->w_size);
     left = s->strstart - s->block_start;
@@ -1858,7 +1831,7 @@ local block_state deflate_stored(s, flush)
         len = MIN(left, have);
         last = flush == Z_FINISH && s->strm->avail_in == 0 &&
                len == left ? 1 : 0;
-        _tr_stored_block(s, (charf *)s->window + s->block_start, len, last);
+        _tr_stored_block(s, (charf *) s->window + s->block_start, len, last);
         s->block_start += len;
         flush_pending(s->strm);
     }
@@ -1874,10 +1847,8 @@ local block_state deflate_stored(s, flush)
  * new strings in the dictionary only for unmatched strings or for short
  * matches. It is used only for the fast compression options.
  */
-local block_state deflate_fast(s, flush)
-    deflate_state *s;
-    int flush;
-{
+local block_state deflate_fast(deflate_state *s,
+                               int flush) {
     IPos hash_head;       /* head of the hash chain */
     int bflush;           /* set if current block must be flushed */
 
@@ -1911,7 +1882,7 @@ local block_state deflate_fast(s, flush)
              * of window index 0 (in particular we have to avoid a match
              * of the string with itself at the start of the input file).
              */
-            s->match_length = longest_match (s, hash_head);
+            s->match_length = longest_match(s, hash_head);
             /* longest_match() sets match_start */
         }
         if (s->match_length >= MIN_MATCH) {
@@ -1953,20 +1924,19 @@ local block_state deflate_fast(s, flush)
             }
         } else {
             /* No match, output a literal byte */
-            Tracevv((stderr,"%c", s->window[s->strstart]));
+            Tracevv((stderr, "%c", s->window[s->strstart]));
             _tr_tally_lit(s, s->window[s->strstart], bflush);
             s->lookahead--;
             s->strstart++;
         }
         if (bflush) FLUSH_BLOCK(s, 0);
     }
-    s->insert = s->strstart < MIN_MATCH-1 ? s->strstart : MIN_MATCH-1;
+    s->insert = s->strstart < MIN_MATCH - 1 ? s->strstart : MIN_MATCH - 1;
     if (flush == Z_FINISH) {
         FLUSH_BLOCK(s, 1);
         return finish_done;
     }
-    if (s->sym_next)
-        FLUSH_BLOCK(s, 0);
+    if (s->sym_next) FLUSH_BLOCK(s, 0);
     return block_done;
 }
 
@@ -1976,10 +1946,8 @@ local block_state deflate_fast(s, flush)
  * evaluation for matches: a match is finally adopted only if there is
  * no better match at the next window position.
  */
-local block_state deflate_slow(s, flush)
-    deflate_state *s;
-    int flush;
-{
+local block_state deflate_slow(deflate_state *s,
+                               int flush) {
     IPos hash_head;          /* head of hash chain */
     int bflush;              /* set if current block must be flushed */
 
@@ -2009,7 +1977,7 @@ local block_state deflate_slow(s, flush)
         /* Find the longest match, discarding those <= prev_length.
          */
         s->prev_length = s->match_length, s->prev_match = s->match_start;
-        s->match_length = MIN_MATCH-1;
+        s->match_length = MIN_MATCH - 1;
 
         if (hash_head != NIL && s->prev_length < s->max_lazy_match &&
             s->strstart - hash_head <= MAX_DIST(s)) {
@@ -2017,20 +1985,20 @@ local block_state deflate_slow(s, flush)
              * of window index 0 (in particular we have to avoid a match
              * of the string with itself at the start of the input file).
              */
-            s->match_length = longest_match (s, hash_head);
+            s->match_length = longest_match(s, hash_head);
             /* longest_match() sets match_start */
 
             if (s->match_length <= 5 && (s->strategy == Z_FILTERED
-#if TOO_FAR <= 32767
-                || (s->match_length == MIN_MATCH &&
-                    s->strstart - s->match_start > TOO_FAR)
+                                         #if TOO_FAR <= 32767
+                                         || (s->match_length == MIN_MATCH &&
+                                             s->strstart - s->match_start > TOO_FAR)
 #endif
-                )) {
+            )) {
 
                 /* If prev_match is also MIN_MATCH, match_start is garbage
                  * but we will ignore the current match anyway.
                  */
-                s->match_length = MIN_MATCH-1;
+                s->match_length = MIN_MATCH - 1;
             }
         }
         /* If there was a match at the previous step and the current
@@ -2058,7 +2026,7 @@ local block_state deflate_slow(s, flush)
                 }
             } while (--s->prev_length != 0);
             s->match_available = 0;
-            s->match_length = MIN_MATCH-1;
+            s->match_length = MIN_MATCH - 1;
             s->strstart++;
 
             if (bflush) FLUSH_BLOCK(s, 0);
@@ -2068,7 +2036,7 @@ local block_state deflate_slow(s, flush)
              * single literal. If there was a match but the current match
              * is longer, truncate the previous match to a single literal.
              */
-            Tracevv((stderr,"%c", s->window[s->strstart - 1]));
+            Tracevv((stderr, "%c", s->window[s->strstart - 1]));
             _tr_tally_lit(s, s->window[s->strstart - 1], bflush);
             if (bflush) {
                 FLUSH_BLOCK_ONLY(s, 0);
@@ -2087,19 +2055,19 @@ local block_state deflate_slow(s, flush)
     }
     Assert (flush != Z_NO_FLUSH, "no flush?");
     if (s->match_available) {
-        Tracevv((stderr,"%c", s->window[s->strstart - 1]));
+        Tracevv((stderr, "%c", s->window[s->strstart - 1]));
         _tr_tally_lit(s, s->window[s->strstart - 1], bflush);
         s->match_available = 0;
     }
-    s->insert = s->strstart < MIN_MATCH-1 ? s->strstart : MIN_MATCH-1;
+    s->insert = s->strstart < MIN_MATCH - 1 ? s->strstart : MIN_MATCH - 1;
     if (flush == Z_FINISH) {
         FLUSH_BLOCK(s, 1);
         return finish_done;
     }
-    if (s->sym_next)
-        FLUSH_BLOCK(s, 0);
+    if (s->sym_next) FLUSH_BLOCK(s, 0);
     return block_done;
 }
+
 #endif /* FASTEST */
 
 /* ===========================================================================
@@ -2107,10 +2075,8 @@ local block_state deflate_slow(s, flush)
  * one.  Do not maintain a hash table.  (It will be regenerated if this run of
  * deflate switches away from Z_RLE.)
  */
-local block_state deflate_rle(s, flush)
-    deflate_state *s;
-    int flush;
-{
+local block_state deflate_rle(deflate_state *s,
+                              int flush) {
     int bflush;             /* set if current block must be flushed */
     uInt prev;              /* byte at distance one to match */
     Bytef *scan, *strend;   /* scan goes up to strend for length of run */
@@ -2141,11 +2107,11 @@ local block_state deflate_rle(s, flush)
                          prev == *++scan && prev == *++scan &&
                          prev == *++scan && prev == *++scan &&
                          scan < strend);
-                s->match_length = MAX_MATCH - (uInt)(strend - scan);
+                s->match_length = MAX_MATCH - (uInt) (strend - scan);
                 if (s->match_length > s->lookahead)
                     s->match_length = s->lookahead;
             }
-            Assert(scan <= s->window + (uInt)(s->window_size - 1),
+            Assert(scan <= s->window + (uInt) (s->window_size - 1),
                    "wild scan");
         }
 
@@ -2160,7 +2126,7 @@ local block_state deflate_rle(s, flush)
             s->match_length = 0;
         } else {
             /* No match, output a literal byte */
-            Tracevv((stderr,"%c", s->window[s->strstart]));
+            Tracevv((stderr, "%c", s->window[s->strstart]));
             _tr_tally_lit(s, s->window[s->strstart], bflush);
             s->lookahead--;
             s->strstart++;
@@ -2172,8 +2138,7 @@ local block_state deflate_rle(s, flush)
         FLUSH_BLOCK(s, 1);
         return finish_done;
     }
-    if (s->sym_next)
-        FLUSH_BLOCK(s, 0);
+    if (s->sym_next) FLUSH_BLOCK(s, 0);
     return block_done;
 }
 
@@ -2181,10 +2146,8 @@ local block_state deflate_rle(s, flush)
  * For Z_HUFFMAN_ONLY, do not look for matches.  Do not maintain a hash table.
  * (It will be regenerated if this run of deflate switches away from Huffman.)
  */
-local block_state deflate_huff(s, flush)
-    deflate_state *s;
-    int flush;
-{
+local block_state deflate_huff(deflate_state *s,
+                               int flush) {
     int bflush;             /* set if current block must be flushed */
 
     for (;;) {
@@ -2200,7 +2163,7 @@ local block_state deflate_huff(s, flush)
 
         /* Output a literal byte */
         s->match_length = 0;
-        Tracevv((stderr,"%c", s->window[s->strstart]));
+        Tracevv((stderr, "%c", s->window[s->strstart]));
         _tr_tally_lit(s, s->window[s->strstart], bflush);
         s->lookahead--;
         s->strstart++;
@@ -2211,7 +2174,6 @@ local block_state deflate_huff(s, flush)
         FLUSH_BLOCK(s, 1);
         return finish_done;
     }
-    if (s->sym_next)
-        FLUSH_BLOCK(s, 0);
+    if (s->sym_next) FLUSH_BLOCK(s, 0);
     return block_done;
 }

--- a/external/zlib/gzclose.c
+++ b/external/zlib/gzclose.c
@@ -8,15 +8,13 @@
 /* gzclose() is in a separate file so that it is linked in only if it is used.
    That way the other gzclose functions can be used instead to avoid linking in
    unneeded compression or decompression routines. */
-int ZEXPORT gzclose(file)
-    gzFile file;
-{
+int ZEXPORT gzclose(gzFile file) {
 #ifndef NO_GZCOMPRESS
     gz_statep state;
 
     if (file == NULL)
         return Z_STREAM_ERROR;
-    state = (gz_statep)file;
+    state = (gz_statep) file;
 
     return state->mode == GZ_READ ? gzclose_r(file) : gzclose_w(file);
 #else

--- a/external/zlib/gzlib.c
+++ b/external/zlib/gzlib.c
@@ -8,7 +8,7 @@
 #if defined(_WIN32) && !defined(__BORLANDC__)
 #  define LSEEK _lseeki64
 #else
-#if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0
+#if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE - 0
 #  define LSEEK lseek64
 #else
 #  define LSEEK lseek
@@ -17,6 +17,7 @@
 
 /* Local functions */
 local void gz_reset OF((gz_statep));
+
 local gzFile gz_open OF((const void *, int, const char *));
 
 #if defined UNDER_CE
@@ -72,16 +73,13 @@ char ZLIB_INTERNAL *gz_strwinerror(error)
 #endif /* UNDER_CE */
 
 /* Reset gzip file state */
-local void gz_reset(state)
-    gz_statep state;
-{
+local void gz_reset(gz_statep state) {
     state->x.have = 0;              /* no output data available */
     if (state->mode == GZ_READ) {   /* for reading ... */
         state->eof = 0;             /* not at end of file */
         state->past = 0;            /* have not read past end yet */
         state->how = LOOK;          /* look for gzip header */
-    }
-    else                            /* for writing ... */
+    } else                            /* for writing ... */
         state->reset = 0;           /* no deflateReset pending */
     state->seek = 0;                /* no seek request pending */
     gz_error(state, Z_OK, NULL);    /* clear error */
@@ -90,11 +88,9 @@ local void gz_reset(state)
 }
 
 /* Open a gzip file either by name or file descriptor. */
-local gzFile gz_open(path, fd, mode)
-    const void *path;
-    int fd;
-    const char *mode;
-{
+local gzFile gz_open(const void *path,
+                     int fd,
+                     const char *mode) {
     gz_statep state;
     z_size_t len;
     int oflag;
@@ -110,7 +106,7 @@ local gzFile gz_open(path, fd, mode)
         return NULL;
 
     /* allocate gzFile structure to return */
-    state = (gz_statep)malloc(sizeof(gz_state));
+    state = (gz_statep) malloc(sizeof(gz_state));
     if (state == NULL)
         return NULL;
     state->size = 0;            /* no buffers allocated yet */
@@ -127,49 +123,49 @@ local gzFile gz_open(path, fd, mode)
             state->level = *mode - '0';
         else
             switch (*mode) {
-            case 'r':
-                state->mode = GZ_READ;
-                break;
+                case 'r':
+                    state->mode = GZ_READ;
+                    break;
 #ifndef NO_GZCOMPRESS
-            case 'w':
-                state->mode = GZ_WRITE;
-                break;
-            case 'a':
-                state->mode = GZ_APPEND;
-                break;
+                case 'w':
+                    state->mode = GZ_WRITE;
+                    break;
+                case 'a':
+                    state->mode = GZ_APPEND;
+                    break;
 #endif
-            case '+':       /* can't read and write at the same time */
-                free(state);
-                return NULL;
-            case 'b':       /* ignore -- will request binary anyway */
-                break;
+                case '+':       /* can't read and write at the same time */
+                    free(state);
+                    return NULL;
+                case 'b':       /* ignore -- will request binary anyway */
+                    break;
 #ifdef O_CLOEXEC
-            case 'e':
-                cloexec = 1;
-                break;
+                    case 'e':
+                        cloexec = 1;
+                        break;
 #endif
 #ifdef O_EXCL
-            case 'x':
-                exclusive = 1;
-                break;
+                    case 'x':
+                        exclusive = 1;
+                        break;
 #endif
-            case 'f':
-                state->strategy = Z_FILTERED;
-                break;
-            case 'h':
-                state->strategy = Z_HUFFMAN_ONLY;
-                break;
-            case 'R':
-                state->strategy = Z_RLE;
-                break;
-            case 'F':
-                state->strategy = Z_FIXED;
-                break;
-            case 'T':
-                state->direct = 1;
-                break;
-            default:        /* could consider as an error, but just ignore */
-                ;
+                case 'f':
+                    state->strategy = Z_FILTERED;
+                    break;
+                case 'h':
+                    state->strategy = Z_HUFFMAN_ONLY;
+                    break;
+                case 'R':
+                    state->strategy = Z_RLE;
+                    break;
+                case 'F':
+                    state->strategy = Z_FIXED;
+                    break;
+                case 'T':
+                    state->direct = 1;
+                    break;
+                default:        /* could consider as an error, but just ignore */
+                    ;
             }
         mode++;
     }
@@ -198,8 +194,8 @@ local gzFile gz_open(path, fd, mode)
     }
     else
 #endif
-        len = strlen((const char *)path);
-    state->path = (char *)malloc(len + 1);
+    len = strlen((const char *) path);
+    state->path = (char *) malloc(len + 1);
     if (state->path == NULL) {
         free(state);
         return NULL;
@@ -213,38 +209,38 @@ local gzFile gz_open(path, fd, mode)
     else
 #endif
 #if !defined(NO_snprintf) && !defined(NO_vsnprintf)
-        (void)snprintf(state->path, len + 1, "%s", (const char *)path);
+    (void) snprintf(state->path, len + 1, "%s", (const char *) path);
 #else
-        strcpy(state->path, path);
+    strcpy(state->path, path);
 #endif
 
     /* compute the flags for open() */
     oflag =
 #ifdef O_LARGEFILE
-        O_LARGEFILE |
+            O_LARGEFILE |
 #endif
 #ifdef O_BINARY
-        O_BINARY |
+            O_BINARY |
 #endif
 #ifdef O_CLOEXEC
-        (cloexec ? O_CLOEXEC : 0) |
+            (cloexec ? O_CLOEXEC : 0) |
 #endif
-        (state->mode == GZ_READ ?
-         O_RDONLY :
-         (O_WRONLY | O_CREAT |
-#ifdef O_EXCL
-          (exclusive ? O_EXCL : 0) |
-#endif
-          (state->mode == GZ_WRITE ?
-           O_TRUNC :
-           O_APPEND)));
+            (state->mode == GZ_READ ?
+             O_RDONLY :
+             (O_WRONLY | O_CREAT |
+              #ifdef O_EXCL
+              (exclusive ? O_EXCL : 0) |
+              #endif
+              (state->mode == GZ_WRITE ?
+               O_TRUNC :
+               O_APPEND)));
 
     /* open the file with the appropriate flags (or just use fd) */
     state->fd = fd > -1 ? fd : (
 #ifdef WIDECHAR
-        fd == -2 ? _wopen(path, oflag, 0666) :
+            fd == -2 ? _wopen(path, oflag, 0666) :
 #endif
-        open((const char *)path, oflag, 0666));
+            open((const char *) path, oflag, 0666));
     if (state->fd == -1) {
         free(state->path);
         free(state);
@@ -265,37 +261,31 @@ local gzFile gz_open(path, fd, mode)
     gz_reset(state);
 
     /* return stream */
-    return (gzFile)state;
+    return (gzFile) state;
 }
 
 /* -- see zlib.h -- */
-gzFile ZEXPORT gzopen(path, mode)
-    const char *path;
-    const char *mode;
-{
+gzFile ZEXPORT gzopen(const char *path,
+                      const char *mode) {
     return gz_open(path, -1, mode);
 }
 
 /* -- see zlib.h -- */
-gzFile ZEXPORT gzopen64(path, mode)
-    const char *path;
-    const char *mode;
-{
+gzFile ZEXPORT gzopen64(const char *path,
+                        const char *mode) {
     return gz_open(path, -1, mode);
 }
 
 /* -- see zlib.h -- */
-gzFile ZEXPORT gzdopen(fd, mode)
-    int fd;
-    const char *mode;
-{
+gzFile ZEXPORT gzdopen(int fd,
+                       const char *mode) {
     char *path;         /* identifier for error messages */
     gzFile gz;
 
-    if (fd == -1 || (path = (char *)malloc(7 + 3 * sizeof(int))) == NULL)
+    if (fd == -1 || (path = (char *) malloc(7 + 3 * sizeof(int))) == NULL)
         return NULL;
 #if !defined(NO_snprintf) && !defined(NO_vsnprintf)
-    (void)snprintf(path, 7 + 3 * sizeof(int), "<fd:%d>", fd);
+    (void) snprintf(path, 7 + 3 * sizeof(int), "<fd:%d>", fd);
 #else
     sprintf(path, "<fd:%d>", fd);   /* for debugging */
 #endif
@@ -315,16 +305,14 @@ gzFile ZEXPORT gzopen_w(path, mode)
 #endif
 
 /* -- see zlib.h -- */
-int ZEXPORT gzbuffer(file, size)
-    gzFile file;
-    unsigned size;
-{
+int ZEXPORT gzbuffer(gzFile file,
+                     unsigned size) {
     gz_statep state;
 
     /* get internal structure and check integrity */
     if (file == NULL)
         return -1;
-    state = (gz_statep)file;
+    state = (gz_statep) file;
     if (state->mode != GZ_READ && state->mode != GZ_WRITE)
         return -1;
 
@@ -342,19 +330,17 @@ int ZEXPORT gzbuffer(file, size)
 }
 
 /* -- see zlib.h -- */
-int ZEXPORT gzrewind(file)
-    gzFile file;
-{
+int ZEXPORT gzrewind(gzFile file) {
     gz_statep state;
 
     /* get internal structure */
     if (file == NULL)
         return -1;
-    state = (gz_statep)file;
+    state = (gz_statep) file;
 
     /* check that we're reading and that there's no error */
     if (state->mode != GZ_READ ||
-            (state->err != Z_OK && state->err != Z_BUF_ERROR))
+        (state->err != Z_OK && state->err != Z_BUF_ERROR))
         return -1;
 
     /* back up and start over */
@@ -365,11 +351,9 @@ int ZEXPORT gzrewind(file)
 }
 
 /* -- see zlib.h -- */
-z_off64_t ZEXPORT gzseek64(file, offset, whence)
-    gzFile file;
-    z_off64_t offset;
-    int whence;
-{
+z_off64_t ZEXPORT gzseek64(gzFile file,
+                           z_off64_t offset,
+                           int whence) {
     unsigned n;
     z_off64_t ret;
     gz_statep state;
@@ -377,7 +361,7 @@ z_off64_t ZEXPORT gzseek64(file, offset, whence)
     /* get internal structure and check integrity */
     if (file == NULL)
         return -1;
-    state = (gz_statep)file;
+    state = (gz_statep) file;
     if (state->mode != GZ_READ && state->mode != GZ_WRITE)
         return -1;
 
@@ -398,8 +382,8 @@ z_off64_t ZEXPORT gzseek64(file, offset, whence)
 
     /* if within raw area while reading, just go there */
     if (state->mode == GZ_READ && state->how == COPY &&
-            state->x.pos + offset >= 0) {
-        ret = LSEEK(state->fd, offset - (z_off64_t)state->x.have, SEEK_CUR);
+        state->x.pos + offset >= 0) {
+        ret = LSEEK(state->fd, offset - (z_off64_t) state->x.have, SEEK_CUR);
         if (ret == -1)
             return -1;
         state->x.have = 0;
@@ -425,8 +409,8 @@ z_off64_t ZEXPORT gzseek64(file, offset, whence)
 
     /* if reading, skip what's in output buffer (one less gzgetc() check) */
     if (state->mode == GZ_READ) {
-        n = GT_OFF(state->x.have) || (z_off64_t)state->x.have > offset ?
-            (unsigned)offset : state->x.have;
+        n = GT_OFF(state->x.have) || (z_off64_t) state->x.have > offset ?
+            (unsigned) offset : state->x.have;
         state->x.have -= n;
         state->x.next += n;
         state->x.pos += n;
@@ -442,27 +426,23 @@ z_off64_t ZEXPORT gzseek64(file, offset, whence)
 }
 
 /* -- see zlib.h -- */
-z_off_t ZEXPORT gzseek(file, offset, whence)
-    gzFile file;
-    z_off_t offset;
-    int whence;
-{
+z_off_t ZEXPORT gzseek(gzFile file,
+                       z_off_t offset,
+                       int whence) {
     z_off64_t ret;
 
-    ret = gzseek64(file, (z_off64_t)offset, whence);
-    return ret == (z_off_t)ret ? (z_off_t)ret : -1;
+    ret = gzseek64(file, (z_off64_t) offset, whence);
+    return ret == (z_off_t) ret ? (z_off_t) ret : -1;
 }
 
 /* -- see zlib.h -- */
-z_off64_t ZEXPORT gztell64(file)
-    gzFile file;
-{
+z_off64_t ZEXPORT gztell64(gzFile file) {
     gz_statep state;
 
     /* get internal structure and check integrity */
     if (file == NULL)
         return -1;
-    state = (gz_statep)file;
+    state = (gz_statep) file;
     if (state->mode != GZ_READ && state->mode != GZ_WRITE)
         return -1;
 
@@ -471,26 +451,22 @@ z_off64_t ZEXPORT gztell64(file)
 }
 
 /* -- see zlib.h -- */
-z_off_t ZEXPORT gztell(file)
-    gzFile file;
-{
+z_off_t ZEXPORT gztell(gzFile file) {
     z_off64_t ret;
 
     ret = gztell64(file);
-    return ret == (z_off_t)ret ? (z_off_t)ret : -1;
+    return ret == (z_off_t) ret ? (z_off_t) ret : -1;
 }
 
 /* -- see zlib.h -- */
-z_off64_t ZEXPORT gzoffset64(file)
-    gzFile file;
-{
+z_off64_t ZEXPORT gzoffset64(gzFile file) {
     z_off64_t offset;
     gz_statep state;
 
     /* get internal structure and check integrity */
     if (file == NULL)
         return -1;
-    state = (gz_statep)file;
+    state = (gz_statep) file;
     if (state->mode != GZ_READ && state->mode != GZ_WRITE)
         return -1;
 
@@ -504,25 +480,20 @@ z_off64_t ZEXPORT gzoffset64(file)
 }
 
 /* -- see zlib.h -- */
-z_off_t ZEXPORT gzoffset(file)
-    gzFile file;
-{
+z_off_t ZEXPORT gzoffset(gzFile file) {
     z_off64_t ret;
-
     ret = gzoffset64(file);
-    return ret == (z_off_t)ret ? (z_off_t)ret : -1;
+    return ret == (z_off_t) ret ? (z_off_t) ret : -1;
 }
 
 /* -- see zlib.h -- */
-int ZEXPORT gzeof(file)
-    gzFile file;
-{
+int ZEXPORT gzeof(gzFile file) {
     gz_statep state;
 
     /* get internal structure and check integrity */
     if (file == NULL)
         return 0;
-    state = (gz_statep)file;
+    state = (gz_statep) file;
     if (state->mode != GZ_READ && state->mode != GZ_WRITE)
         return 0;
 
@@ -531,16 +502,14 @@ int ZEXPORT gzeof(file)
 }
 
 /* -- see zlib.h -- */
-const char * ZEXPORT gzerror(file, errnum)
-    gzFile file;
-    int *errnum;
-{
+const char *ZEXPORT gzerror(gzFile file,
+                            int *errnum) {
     gz_statep state;
 
     /* get internal structure and check integrity */
     if (file == NULL)
         return NULL;
-    state = (gz_statep)file;
+    state = (gz_statep) file;
     if (state->mode != GZ_READ && state->mode != GZ_WRITE)
         return NULL;
 
@@ -548,19 +517,17 @@ const char * ZEXPORT gzerror(file, errnum)
     if (errnum != NULL)
         *errnum = state->err;
     return state->err == Z_MEM_ERROR ? "out of memory" :
-                                       (state->msg == NULL ? "" : state->msg);
+           (state->msg == NULL ? "" : state->msg);
 }
 
 /* -- see zlib.h -- */
-void ZEXPORT gzclearerr(file)
-    gzFile file;
-{
+void ZEXPORT gzclearerr(gzFile file) {
     gz_statep state;
 
     /* get internal structure and check integrity */
     if (file == NULL)
         return;
-    state = (gz_statep)file;
+    state = (gz_statep) file;
     if (state->mode != GZ_READ && state->mode != GZ_WRITE)
         return;
 
@@ -578,11 +545,9 @@ void ZEXPORT gzclearerr(file)
    memory).  Simply save the error message as a static string.  If there is an
    allocation failure constructing the error message, then convert the error to
    out of memory. */
-void ZLIB_INTERNAL gz_error(state, err, msg)
-    gz_statep state;
-    int err;
-    const char *msg;
-{
+void ZLIB_INTERNAL gz_error(gz_statep state,
+                            int err,
+                            const char *msg) {
     /* free previously allocated message and clear */
     if (state->msg != NULL) {
         if (state->err != Z_MEM_ERROR)
@@ -604,14 +569,14 @@ void ZLIB_INTERNAL gz_error(state, err, msg)
         return;
 
     /* construct error message with path */
-    if ((state->msg = (char *)malloc(strlen(state->path) + strlen(msg) + 3)) ==
-            NULL) {
+    if ((state->msg = (char *) malloc(strlen(state->path) + strlen(msg) + 3)) ==
+        NULL) {
         state->err = Z_MEM_ERROR;
         return;
     }
 #if !defined(NO_snprintf) && !defined(NO_vsnprintf)
-    (void)snprintf(state->msg, strlen(state->path) + strlen(msg) + 3,
-                   "%s%s%s", state->path, ": ", msg);
+    (void) snprintf(state->msg, strlen(state->path) + strlen(msg) + 3,
+                    "%s%s%s", state->path, ": ", msg);
 #else
     strcpy(state->msg, state->path);
     strcat(state->msg, ": ");
@@ -620,12 +585,12 @@ void ZLIB_INTERNAL gz_error(state, err, msg)
 }
 
 #ifndef INT_MAX
+
 /* portably return maximum value for an int (when limits.h presumed not
    available) -- we need to do this to cover cases where 2's complement not
    used, since C standard permits 1's complement and sign-bit representations,
    otherwise we could just use ((unsigned)-1) >> 1 */
-unsigned ZLIB_INTERNAL gz_intmax()
-{
+unsigned ZLIB_INTERNAL gz_intmax() {
     unsigned p, q;
 
     p = 1;
@@ -636,4 +601,5 @@ unsigned ZLIB_INTERNAL gz_intmax()
     } while (p > q);
     return q >> 1;
 }
+
 #endif

--- a/external/zlib/infback.c
+++ b/external/zlib/infback.c
@@ -25,43 +25,41 @@ local void fixedtables OF((struct inflate_state FAR *state));
    windowBits is in the range 8..15, and window is a user-supplied
    window and output buffer that is 2**windowBits bytes.
  */
-int ZEXPORT inflateBackInit_(strm, windowBits, window, version, stream_size)
-z_streamp strm;
-int windowBits;
-unsigned char FAR *window;
-const char *version;
-int stream_size;
-{
+int ZEXPORT inflateBackInit_(z_streamp strm,
+                             int windowBits,
+                             unsigned char FAR *window,
+                             const char *version,
+                             int stream_size) {
     struct inflate_state FAR *state;
 
     if (version == Z_NULL || version[0] != ZLIB_VERSION[0] ||
-        stream_size != (int)(sizeof(z_stream)))
+        stream_size != (int) (sizeof(z_stream)))
         return Z_VERSION_ERROR;
     if (strm == Z_NULL || window == Z_NULL ||
         windowBits < 8 || windowBits > 15)
         return Z_STREAM_ERROR;
     strm->msg = Z_NULL;                 /* in case we return an error */
-    if (strm->zalloc == (alloc_func)0) {
+    if (strm->zalloc == (alloc_func) 0) {
 #ifdef Z_SOLO
         return Z_STREAM_ERROR;
 #else
         strm->zalloc = zcalloc;
-        strm->opaque = (voidpf)0;
+        strm->opaque = (voidpf) 0;
 #endif
     }
-    if (strm->zfree == (free_func)0)
+    if (strm->zfree == (free_func) 0)
 #ifdef Z_SOLO
         return Z_STREAM_ERROR;
 #else
-    strm->zfree = zcfree;
+        strm->zfree = zcfree;
 #endif
-    state = (struct inflate_state FAR *)ZALLOC(strm, 1,
-                                               sizeof(struct inflate_state));
+    state = (struct inflate_state FAR *) ZALLOC(strm, 1,
+                                                sizeof(struct inflate_state));
     if (state == Z_NULL) return Z_MEM_ERROR;
     Tracev((stderr, "inflate: allocated\n"));
-    strm->state = (struct internal_state FAR *)state;
+    strm->state = (struct internal_state FAR *) state;
     state->dmax = 32768U;
-    state->wbits = (uInt)windowBits;
+    state->wbits = (uInt) windowBits;
     state->wsize = 1U << windowBits;
     state->window = window;
     state->wnext = 0;
@@ -80,9 +78,7 @@ int stream_size;
    used for threaded applications, since the rewriting of the tables and virgin
    may not be thread-safe.
  */
-local void fixedtables(state)
-struct inflate_state FAR *state;
-{
+local void fixedtables(struct inflate_state FAR *state) {
 #ifdef BUILDFIXED
     static int virgin = 1;
     static code *lenfix, *distfix;
@@ -115,7 +111,9 @@ struct inflate_state FAR *state;
         virgin = 0;
     }
 #else /* !BUILDFIXED */
+
 #   include "inffixed.h"
+
 #endif /* BUILDFIXED */
     state->lencode = lenfix;
     state->lenbits = 9;
@@ -248,13 +246,11 @@ struct inflate_state FAR *state;
    inflateBack() can also return Z_STREAM_ERROR if the input parameters
    are not correct, i.e. strm is Z_NULL or the state was not initialized.
  */
-int ZEXPORT inflateBack(strm, in, in_desc, out, out_desc)
-z_streamp strm;
-in_func in;
-void FAR *in_desc;
-out_func out;
-void FAR *out_desc;
-{
+int ZEXPORT inflateBack(z_streamp strm,
+                        in_func in,
+                        void FAR *in_desc,
+                        out_func out,
+                        void FAR *out_desc) {
     struct inflate_state FAR *state;
     z_const unsigned char FAR *next;    /* next input */
     unsigned char FAR *put;     /* next output */
@@ -268,12 +264,12 @@ void FAR *out_desc;
     unsigned len;               /* length to copy for repeats, bits to drop */
     int ret;                    /* return code */
     static const unsigned short order[19] = /* permutation of code lengths */
-        {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
+            {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
 
     /* Check that the strm exists and that the state was initialized */
     if (strm == Z_NULL || strm->state == Z_NULL)
         return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
 
     /* Reset the state */
     strm->msg = Z_NULL;
@@ -290,338 +286,334 @@ void FAR *out_desc;
     /* Inflate until end of block marked as last */
     for (;;)
         switch (state->mode) {
-        case TYPE:
-            /* determine and dispatch block type */
-            if (state->last) {
-                BYTEBITS();
-                state->mode = DONE;
-                break;
-            }
-            NEEDBITS(3);
-            state->last = BITS(1);
-            DROPBITS(1);
-            switch (BITS(2)) {
-            case 0:                             /* stored block */
-                Tracev((stderr, "inflate:     stored block%s\n",
-                        state->last ? " (last)" : ""));
-                state->mode = STORED;
-                break;
-            case 1:                             /* fixed block */
-                fixedtables(state);
-                Tracev((stderr, "inflate:     fixed codes block%s\n",
-                        state->last ? " (last)" : ""));
-                state->mode = LEN;              /* decode codes */
-                break;
-            case 2:                             /* dynamic block */
-                Tracev((stderr, "inflate:     dynamic codes block%s\n",
-                        state->last ? " (last)" : ""));
-                state->mode = TABLE;
-                break;
-            case 3:
-                strm->msg = (char *)"invalid block type";
-                state->mode = BAD;
-            }
-            DROPBITS(2);
-            break;
-
-        case STORED:
-            /* get and verify stored block length */
-            BYTEBITS();                         /* go to byte boundary */
-            NEEDBITS(32);
-            if ((hold & 0xffff) != ((hold >> 16) ^ 0xffff)) {
-                strm->msg = (char *)"invalid stored block lengths";
-                state->mode = BAD;
-                break;
-            }
-            state->length = (unsigned)hold & 0xffff;
-            Tracev((stderr, "inflate:       stored length %u\n",
-                    state->length));
-            INITBITS();
-
-            /* copy stored block from input to output */
-            while (state->length != 0) {
-                copy = state->length;
-                PULL();
-                ROOM();
-                if (copy > have) copy = have;
-                if (copy > left) copy = left;
-                zmemcpy(put, next, copy);
-                have -= copy;
-                next += copy;
-                left -= copy;
-                put += copy;
-                state->length -= copy;
-            }
-            Tracev((stderr, "inflate:       stored end\n"));
-            state->mode = TYPE;
-            break;
-
-        case TABLE:
-            /* get dynamic table entries descriptor */
-            NEEDBITS(14);
-            state->nlen = BITS(5) + 257;
-            DROPBITS(5);
-            state->ndist = BITS(5) + 1;
-            DROPBITS(5);
-            state->ncode = BITS(4) + 4;
-            DROPBITS(4);
-#ifndef PKZIP_BUG_WORKAROUND
-            if (state->nlen > 286 || state->ndist > 30) {
-                strm->msg = (char *)"too many length or distance symbols";
-                state->mode = BAD;
-                break;
-            }
-#endif
-            Tracev((stderr, "inflate:       table sizes ok\n"));
-
-            /* get code length code lengths (not a typo) */
-            state->have = 0;
-            while (state->have < state->ncode) {
+            case TYPE:
+                /* determine and dispatch block type */
+                if (state->last) {
+                    BYTEBITS();
+                    state->mode = DONE;
+                    break;
+                }
                 NEEDBITS(3);
-                state->lens[order[state->have++]] = (unsigned short)BITS(3);
-                DROPBITS(3);
-            }
-            while (state->have < 19)
-                state->lens[order[state->have++]] = 0;
-            state->next = state->codes;
-            state->lencode = (code const FAR *)(state->next);
-            state->lenbits = 7;
-            ret = inflate_table(CODES, state->lens, 19, &(state->next),
-                                &(state->lenbits), state->work);
-            if (ret) {
-                strm->msg = (char *)"invalid code lengths set";
-                state->mode = BAD;
+                state->last = BITS(1);
+                DROPBITS(1);
+                switch (BITS(2)) {
+                    case 0:                             /* stored block */
+                        Tracev((stderr, "inflate:     stored block%s\n",
+                                state->last ? " (last)" : ""));
+                        state->mode = STORED;
+                        break;
+                    case 1:                             /* fixed block */
+                        fixedtables(state);
+                        Tracev((stderr, "inflate:     fixed codes block%s\n",
+                                state->last ? " (last)" : ""));
+                        state->mode = LEN;              /* decode codes */
+                        break;
+                    case 2:                             /* dynamic block */
+                        Tracev((stderr, "inflate:     dynamic codes block%s\n",
+                                state->last ? " (last)" : ""));
+                        state->mode = TABLE;
+                        break;
+                    case 3:
+                        strm->msg = (char *) "invalid block type";
+                        state->mode = BAD;
+                }
+                DROPBITS(2);
                 break;
-            }
-            Tracev((stderr, "inflate:       code lengths ok\n"));
 
-            /* get length and distance code code lengths */
-            state->have = 0;
-            while (state->have < state->nlen + state->ndist) {
-                for (;;) {
-                    here = state->lencode[BITS(state->lenbits)];
-                    if ((unsigned)(here.bits) <= bits) break;
-                    PULLBYTE();
+            case STORED:
+                /* get and verify stored block length */
+                BYTEBITS();                         /* go to byte boundary */
+                NEEDBITS(32);
+                if ((hold & 0xffff) != ((hold >> 16) ^ 0xffff)) {
+                    strm->msg = (char *) "invalid stored block lengths";
+                    state->mode = BAD;
+                    break;
                 }
-                if (here.val < 16) {
-                    DROPBITS(here.bits);
-                    state->lens[state->have++] = here.val;
+                state->length = (unsigned) hold & 0xffff;
+                Tracev((stderr, "inflate:       stored length %u\n",
+                        state->length));
+                INITBITS();
+
+                /* copy stored block from input to output */
+                while (state->length != 0) {
+                    copy = state->length;
+                    PULL();
+                    ROOM();
+                    if (copy > have) copy = have;
+                    if (copy > left) copy = left;
+                    zmemcpy(put, next, copy);
+                    have -= copy;
+                    next += copy;
+                    left -= copy;
+                    put += copy;
+                    state->length -= copy;
                 }
-                else {
-                    if (here.val == 16) {
-                        NEEDBITS(here.bits + 2);
+                Tracev((stderr, "inflate:       stored end\n"));
+                state->mode = TYPE;
+                break;
+
+            case TABLE:
+                /* get dynamic table entries descriptor */
+                NEEDBITS(14);
+                state->nlen = BITS(5) + 257;
+                DROPBITS(5);
+                state->ndist = BITS(5) + 1;
+                DROPBITS(5);
+                state->ncode = BITS(4) + 4;
+                DROPBITS(4);
+#ifndef PKZIP_BUG_WORKAROUND
+                if (state->nlen > 286 || state->ndist > 30) {
+                    strm->msg = (char *) "too many length or distance symbols";
+                    state->mode = BAD;
+                    break;
+                }
+#endif
+                Tracev((stderr, "inflate:       table sizes ok\n"));
+
+                /* get code length code lengths (not a typo) */
+                state->have = 0;
+                while (state->have < state->ncode) {
+                    NEEDBITS(3);
+                    state->lens[order[state->have++]] = (unsigned short) BITS(3);
+                    DROPBITS(3);
+                }
+                while (state->have < 19)
+                    state->lens[order[state->have++]] = 0;
+                state->next = state->codes;
+                state->lencode = (code const FAR *) (state->next);
+                state->lenbits = 7;
+                ret = inflate_table(CODES, state->lens, 19, &(state->next),
+                                    &(state->lenbits), state->work);
+                if (ret) {
+                    strm->msg = (char *) "invalid code lengths set";
+                    state->mode = BAD;
+                    break;
+                }
+                Tracev((stderr, "inflate:       code lengths ok\n"));
+
+                /* get length and distance code code lengths */
+                state->have = 0;
+                while (state->have < state->nlen + state->ndist) {
+                    for (;;) {
+                        here = state->lencode[BITS(state->lenbits)];
+                        if ((unsigned) (here.bits) <= bits) break;
+                        PULLBYTE();
+                    }
+                    if (here.val < 16) {
                         DROPBITS(here.bits);
-                        if (state->have == 0) {
-                            strm->msg = (char *)"invalid bit length repeat";
+                        state->lens[state->have++] = here.val;
+                    } else {
+                        if (here.val == 16) {
+                            NEEDBITS(here.bits + 2);
+                            DROPBITS(here.bits);
+                            if (state->have == 0) {
+                                strm->msg = (char *) "invalid bit length repeat";
+                                state->mode = BAD;
+                                break;
+                            }
+                            len = (unsigned) (state->lens[state->have - 1]);
+                            copy = 3 + BITS(2);
+                            DROPBITS(2);
+                        } else if (here.val == 17) {
+                            NEEDBITS(here.bits + 3);
+                            DROPBITS(here.bits);
+                            len = 0;
+                            copy = 3 + BITS(3);
+                            DROPBITS(3);
+                        } else {
+                            NEEDBITS(here.bits + 7);
+                            DROPBITS(here.bits);
+                            len = 0;
+                            copy = 11 + BITS(7);
+                            DROPBITS(7);
+                        }
+                        if (state->have + copy > state->nlen + state->ndist) {
+                            strm->msg = (char *) "invalid bit length repeat";
                             state->mode = BAD;
                             break;
                         }
-                        len = (unsigned)(state->lens[state->have - 1]);
-                        copy = 3 + BITS(2);
-                        DROPBITS(2);
+                        while (copy--)
+                            state->lens[state->have++] = (unsigned short) len;
                     }
-                    else if (here.val == 17) {
-                        NEEDBITS(here.bits + 3);
-                        DROPBITS(here.bits);
-                        len = 0;
-                        copy = 3 + BITS(3);
-                        DROPBITS(3);
-                    }
-                    else {
-                        NEEDBITS(here.bits + 7);
-                        DROPBITS(here.bits);
-                        len = 0;
-                        copy = 11 + BITS(7);
-                        DROPBITS(7);
-                    }
-                    if (state->have + copy > state->nlen + state->ndist) {
-                        strm->msg = (char *)"invalid bit length repeat";
-                        state->mode = BAD;
-                        break;
-                    }
-                    while (copy--)
-                        state->lens[state->have++] = (unsigned short)len;
                 }
-            }
 
-            /* handle error breaks in while */
-            if (state->mode == BAD) break;
+                /* handle error breaks in while */
+                if (state->mode == BAD) break;
 
-            /* check for end-of-block code (better have one) */
-            if (state->lens[256] == 0) {
-                strm->msg = (char *)"invalid code -- missing end-of-block";
-                state->mode = BAD;
-                break;
-            }
+                /* check for end-of-block code (better have one) */
+                if (state->lens[256] == 0) {
+                    strm->msg = (char *) "invalid code -- missing end-of-block";
+                    state->mode = BAD;
+                    break;
+                }
 
-            /* build code tables -- note: do not change the lenbits or distbits
-               values here (9 and 6) without reading the comments in inftrees.h
-               concerning the ENOUGH constants, which depend on those values */
-            state->next = state->codes;
-            state->lencode = (code const FAR *)(state->next);
-            state->lenbits = 9;
-            ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
-                                &(state->lenbits), state->work);
-            if (ret) {
-                strm->msg = (char *)"invalid literal/lengths set";
-                state->mode = BAD;
-                break;
-            }
-            state->distcode = (code const FAR *)(state->next);
-            state->distbits = 6;
-            ret = inflate_table(DISTS, state->lens + state->nlen, state->ndist,
-                            &(state->next), &(state->distbits), state->work);
-            if (ret) {
-                strm->msg = (char *)"invalid distances set";
-                state->mode = BAD;
-                break;
-            }
-            Tracev((stderr, "inflate:       codes ok\n"));
-            state->mode = LEN;
+                /* build code tables -- note: do not change the lenbits or distbits
+                   values here (9 and 6) without reading the comments in inftrees.h
+                   concerning the ENOUGH constants, which depend on those values */
+                state->next = state->codes;
+                state->lencode = (code const FAR *) (state->next);
+                state->lenbits = 9;
+                ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
+                                    &(state->lenbits), state->work);
+                if (ret) {
+                    strm->msg = (char *) "invalid literal/lengths set";
+                    state->mode = BAD;
+                    break;
+                }
+                state->distcode = (code const FAR *) (state->next);
+                state->distbits = 6;
+                ret = inflate_table(DISTS, state->lens + state->nlen, state->ndist,
+                                    &(state->next), &(state->distbits), state->work);
+                if (ret) {
+                    strm->msg = (char *) "invalid distances set";
+                    state->mode = BAD;
+                    break;
+                }
+                Tracev((stderr, "inflate:       codes ok\n"));
+                state->mode = LEN;
                 /* fallthrough */
 
-        case LEN:
-            /* use inflate_fast() if we have enough input and output */
-            if (have >= 6 && left >= 258) {
-                RESTORE();
-                if (state->whave < state->wsize)
-                    state->whave = state->wsize - left;
-                inflate_fast(strm, state->wsize);
-                LOAD();
-                break;
-            }
+            case LEN:
+                /* use inflate_fast() if we have enough input and output */
+                if (have >= 6 && left >= 258) {
+                    RESTORE();
+                    if (state->whave < state->wsize)
+                        state->whave = state->wsize - left;
+                    inflate_fast(strm, state->wsize);
+                    LOAD();
+                    break;
+                }
 
-            /* get a literal, length, or end-of-block code */
-            for (;;) {
-                here = state->lencode[BITS(state->lenbits)];
-                if ((unsigned)(here.bits) <= bits) break;
-                PULLBYTE();
-            }
-            if (here.op && (here.op & 0xf0) == 0) {
-                last = here;
+                /* get a literal, length, or end-of-block code */
                 for (;;) {
-                    here = state->lencode[last.val +
-                            (BITS(last.bits + last.op) >> last.bits)];
-                    if ((unsigned)(last.bits + here.bits) <= bits) break;
+                    here = state->lencode[BITS(state->lenbits)];
+                    if ((unsigned) (here.bits) <= bits) break;
                     PULLBYTE();
                 }
-                DROPBITS(last.bits);
-            }
-            DROPBITS(here.bits);
-            state->length = (unsigned)here.val;
+                if (here.op && (here.op & 0xf0) == 0) {
+                    last = here;
+                    for (;;) {
+                        here = state->lencode[last.val +
+                                              (BITS(last.bits + last.op) >> last.bits)];
+                        if ((unsigned) (last.bits + here.bits) <= bits) break;
+                        PULLBYTE();
+                    }
+                    DROPBITS(last.bits);
+                }
+                DROPBITS(here.bits);
+                state->length = (unsigned) here.val;
 
-            /* process literal */
-            if (here.op == 0) {
-                Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
-                        "inflate:         literal '%c'\n" :
-                        "inflate:         literal 0x%02x\n", here.val));
-                ROOM();
-                *put++ = (unsigned char)(state->length);
-                left--;
-                state->mode = LEN;
-                break;
-            }
+                /* process literal */
+                if (here.op == 0) {
+                    Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
+                                     "inflate:         literal '%c'\n" :
+                                     "inflate:         literal 0x%02x\n", here.val));
+                    ROOM();
+                    *put++ = (unsigned char) (state->length);
+                    left--;
+                    state->mode = LEN;
+                    break;
+                }
 
-            /* process end of block */
-            if (here.op & 32) {
-                Tracevv((stderr, "inflate:         end of block\n"));
-                state->mode = TYPE;
-                break;
-            }
+                /* process end of block */
+                if (here.op & 32) {
+                    Tracevv((stderr, "inflate:         end of block\n"));
+                    state->mode = TYPE;
+                    break;
+                }
 
-            /* invalid code */
-            if (here.op & 64) {
-                strm->msg = (char *)"invalid literal/length code";
-                state->mode = BAD;
-                break;
-            }
+                /* invalid code */
+                if (here.op & 64) {
+                    strm->msg = (char *) "invalid literal/length code";
+                    state->mode = BAD;
+                    break;
+                }
 
-            /* length code -- get extra bits, if any */
-            state->extra = (unsigned)(here.op) & 15;
-            if (state->extra != 0) {
-                NEEDBITS(state->extra);
-                state->length += BITS(state->extra);
-                DROPBITS(state->extra);
-            }
-            Tracevv((stderr, "inflate:         length %u\n", state->length));
+                /* length code -- get extra bits, if any */
+                state->extra = (unsigned) (here.op) & 15;
+                if (state->extra != 0) {
+                    NEEDBITS(state->extra);
+                    state->length += BITS(state->extra);
+                    DROPBITS(state->extra);
+                }
+                Tracevv((stderr, "inflate:         length %u\n", state->length));
 
-            /* get distance code */
-            for (;;) {
-                here = state->distcode[BITS(state->distbits)];
-                if ((unsigned)(here.bits) <= bits) break;
-                PULLBYTE();
-            }
-            if ((here.op & 0xf0) == 0) {
-                last = here;
+                /* get distance code */
                 for (;;) {
-                    here = state->distcode[last.val +
-                            (BITS(last.bits + last.op) >> last.bits)];
-                    if ((unsigned)(last.bits + here.bits) <= bits) break;
+                    here = state->distcode[BITS(state->distbits)];
+                    if ((unsigned) (here.bits) <= bits) break;
                     PULLBYTE();
                 }
-                DROPBITS(last.bits);
-            }
-            DROPBITS(here.bits);
-            if (here.op & 64) {
-                strm->msg = (char *)"invalid distance code";
-                state->mode = BAD;
-                break;
-            }
-            state->offset = (unsigned)here.val;
-
-            /* get distance extra bits, if any */
-            state->extra = (unsigned)(here.op) & 15;
-            if (state->extra != 0) {
-                NEEDBITS(state->extra);
-                state->offset += BITS(state->extra);
-                DROPBITS(state->extra);
-            }
-            if (state->offset > state->wsize - (state->whave < state->wsize ?
-                                                left : 0)) {
-                strm->msg = (char *)"invalid distance too far back";
-                state->mode = BAD;
-                break;
-            }
-            Tracevv((stderr, "inflate:         distance %u\n", state->offset));
-
-            /* copy match from window to output */
-            do {
-                ROOM();
-                copy = state->wsize - state->offset;
-                if (copy < left) {
-                    from = put + copy;
-                    copy = left - copy;
+                if ((here.op & 0xf0) == 0) {
+                    last = here;
+                    for (;;) {
+                        here = state->distcode[last.val +
+                                               (BITS(last.bits + last.op) >> last.bits)];
+                        if ((unsigned) (last.bits + here.bits) <= bits) break;
+                        PULLBYTE();
+                    }
+                    DROPBITS(last.bits);
                 }
-                else {
-                    from = put - state->offset;
-                    copy = left;
+                DROPBITS(here.bits);
+                if (here.op & 64) {
+                    strm->msg = (char *) "invalid distance code";
+                    state->mode = BAD;
+                    break;
                 }
-                if (copy > state->length) copy = state->length;
-                state->length -= copy;
-                left -= copy;
+                state->offset = (unsigned) here.val;
+
+                /* get distance extra bits, if any */
+                state->extra = (unsigned) (here.op) & 15;
+                if (state->extra != 0) {
+                    NEEDBITS(state->extra);
+                    state->offset += BITS(state->extra);
+                    DROPBITS(state->extra);
+                }
+                if (state->offset > state->wsize - (state->whave < state->wsize ?
+                                                    left : 0)) {
+                    strm->msg = (char *) "invalid distance too far back";
+                    state->mode = BAD;
+                    break;
+                }
+                Tracevv((stderr, "inflate:         distance %u\n", state->offset));
+
+                /* copy match from window to output */
                 do {
-                    *put++ = *from++;
-                } while (--copy);
-            } while (state->length != 0);
-            break;
+                    ROOM();
+                    copy = state->wsize - state->offset;
+                    if (copy < left) {
+                        from = put + copy;
+                        copy = left - copy;
+                    } else {
+                        from = put - state->offset;
+                        copy = left;
+                    }
+                    if (copy > state->length) copy = state->length;
+                    state->length -= copy;
+                    left -= copy;
+                    do {
+                        *put++ = *from++;
+                    } while (--copy);
+                } while (state->length != 0);
+                break;
 
-        case DONE:
-            /* inflate stream terminated properly */
-            ret = Z_STREAM_END;
-            goto inf_leave;
+            case DONE:
+                /* inflate stream terminated properly */
+                ret = Z_STREAM_END;
+                goto inf_leave;
 
-        case BAD:
-            ret = Z_DATA_ERROR;
-            goto inf_leave;
+            case BAD:
+                ret = Z_DATA_ERROR;
+                goto inf_leave;
 
-        default:
-            /* can't happen, but makes compilers happy */
-            ret = Z_STREAM_ERROR;
-            goto inf_leave;
+            default:
+                /* can't happen, but makes compilers happy */
+                ret = Z_STREAM_ERROR;
+                goto inf_leave;
         }
 
     /* Write leftover output and return unused input */
-  inf_leave:
+    inf_leave:
     if (left < state->wsize) {
         if (out(out_desc, state->window, state->wsize - left) &&
             ret == Z_STREAM_END)
@@ -632,10 +624,8 @@ void FAR *out_desc;
     return ret;
 }
 
-int ZEXPORT inflateBackEnd(strm)
-z_streamp strm;
-{
-    if (strm == Z_NULL || strm->state == Z_NULL || strm->zfree == (free_func)0)
+int ZEXPORT inflateBackEnd(z_streamp strm) {
+    if (strm == Z_NULL || strm->state == Z_NULL || strm->zfree == (free_func) 0)
         return Z_STREAM_ERROR;
     ZFREE(strm, strm->state);
     strm->state = Z_NULL;

--- a/external/zlib/inffast.c
+++ b/external/zlib/inffast.c
@@ -47,10 +47,8 @@
       requires strm->avail_out >= 258 for each loop to avoid checking for
       output space.
  */
-void ZLIB_INTERNAL inflate_fast(strm, start)
-z_streamp strm;
-unsigned start;         /* inflate()'s starting value for strm->avail_out */
-{
+void ZLIB_INTERNAL inflate_fast(z_streamp strm, /* inflate()'s starting value for strm->avail_out */
+                                unsigned start) {
     struct inflate_state FAR *state;
     z_const unsigned char FAR *in;      /* local strm->next_in */
     z_const unsigned char FAR *last;    /* have enough input while in < last */
@@ -72,13 +70,13 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
     unsigned dmask;             /* mask for first level of distance codes */
     code const *here;           /* retrieved table entry */
     unsigned op;                /* code bits, operation, extra bits, or */
-                                /*  window position, window bytes to copy */
+    /*  window position, window bytes to copy */
     unsigned len;               /* match length, unused bytes */
     unsigned dist;              /* match distance */
     unsigned char FAR *from;    /* where to copy match from */
 
     /* copy state to local variables */
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     in = strm->next_in;
     last = in + (strm->avail_in - 5);
     out = strm->next_out;
@@ -102,60 +100,59 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
        input data or output space */
     do {
         if (bits < 15) {
-            hold += (unsigned long)(*in++) << bits;
+            hold += (unsigned long) (*in++) << bits;
             bits += 8;
-            hold += (unsigned long)(*in++) << bits;
+            hold += (unsigned long) (*in++) << bits;
             bits += 8;
         }
         here = lcode + (hold & lmask);
-      dolen:
-        op = (unsigned)(here->bits);
+        dolen:
+        op = (unsigned) (here->bits);
         hold >>= op;
         bits -= op;
-        op = (unsigned)(here->op);
+        op = (unsigned) (here->op);
         if (op == 0) {                          /* literal */
             Tracevv((stderr, here->val >= 0x20 && here->val < 0x7f ?
-                    "inflate:         literal '%c'\n" :
-                    "inflate:         literal 0x%02x\n", here->val));
-            *out++ = (unsigned char)(here->val);
-        }
-        else if (op & 16) {                     /* length base */
-            len = (unsigned)(here->val);
+                             "inflate:         literal '%c'\n" :
+                             "inflate:         literal 0x%02x\n", here->val));
+            *out++ = (unsigned char) (here->val);
+        } else if (op & 16) {                     /* length base */
+            len = (unsigned) (here->val);
             op &= 15;                           /* number of extra bits */
             if (op) {
                 if (bits < op) {
-                    hold += (unsigned long)(*in++) << bits;
+                    hold += (unsigned long) (*in++) << bits;
                     bits += 8;
                 }
-                len += (unsigned)hold & ((1U << op) - 1);
+                len += (unsigned) hold & ((1U << op) - 1);
                 hold >>= op;
                 bits -= op;
             }
             Tracevv((stderr, "inflate:         length %u\n", len));
             if (bits < 15) {
-                hold += (unsigned long)(*in++) << bits;
+                hold += (unsigned long) (*in++) << bits;
                 bits += 8;
-                hold += (unsigned long)(*in++) << bits;
+                hold += (unsigned long) (*in++) << bits;
                 bits += 8;
             }
             here = dcode + (hold & dmask);
-          dodist:
-            op = (unsigned)(here->bits);
+            dodist:
+            op = (unsigned) (here->bits);
             hold >>= op;
             bits -= op;
-            op = (unsigned)(here->op);
+            op = (unsigned) (here->op);
             if (op & 16) {                      /* distance base */
-                dist = (unsigned)(here->val);
+                dist = (unsigned) (here->val);
                 op &= 15;                       /* number of extra bits */
                 if (bits < op) {
-                    hold += (unsigned long)(*in++) << bits;
+                    hold += (unsigned long) (*in++) << bits;
                     bits += 8;
                     if (bits < op) {
-                        hold += (unsigned long)(*in++) << bits;
+                        hold += (unsigned long) (*in++) << bits;
                         bits += 8;
                     }
                 }
-                dist += (unsigned)hold & ((1U << op) - 1);
+                dist += (unsigned) hold & ((1U << op) - 1);
 #ifdef INFLATE_STRICT
                 if (dist > dmax) {
                     strm->msg = (char *)"invalid distance too far back";
@@ -166,13 +163,13 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
                 hold >>= op;
                 bits -= op;
                 Tracevv((stderr, "inflate:         distance %u\n", dist));
-                op = (unsigned)(out - beg);     /* max distance in output */
+                op = (unsigned) (out - beg);     /* max distance in output */
                 if (dist > op) {                /* see if copy from window */
                     op = dist - op;             /* distance back in window */
                     if (op > whave) {
                         if (state->sane) {
                             strm->msg =
-                                (char *)"invalid distance too far back";
+                                    (char *) "invalid distance too far back";
                             state->mode = BAD;
                             break;
                         }
@@ -206,8 +203,7 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
                             } while (--op);
                             from = out - dist;  /* rest from output */
                         }
-                    }
-                    else if (wnext < op) {      /* wrap around window */
+                    } else if (wnext < op) {      /* wrap around window */
                         from += wsize + wnext - op;
                         op -= wnext;
                         if (op < len) {         /* some from end of window */
@@ -225,8 +221,7 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
                                 from = out - dist;      /* rest from output */
                             }
                         }
-                    }
-                    else {                      /* contiguous in window */
+                    } else {                      /* contiguous in window */
                         from += wnext - op;
                         if (op < len) {         /* some from window */
                             len -= op;
@@ -247,8 +242,7 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
                         if (len > 1)
                             *out++ = *from++;
                     }
-                }
-                else {
+                } else {
                     from = out - dist;          /* copy direct from output */
                     do {                        /* minimum length is three */
                         *out++ = *from++;
@@ -262,28 +256,23 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
                             *out++ = *from++;
                     }
                 }
-            }
-            else if ((op & 64) == 0) {          /* 2nd level distance code */
+            } else if ((op & 64) == 0) {          /* 2nd level distance code */
                 here = dcode + here->val + (hold & ((1U << op) - 1));
                 goto dodist;
-            }
-            else {
-                strm->msg = (char *)"invalid distance code";
+            } else {
+                strm->msg = (char *) "invalid distance code";
                 state->mode = BAD;
                 break;
             }
-        }
-        else if ((op & 64) == 0) {              /* 2nd level length code */
+        } else if ((op & 64) == 0) {              /* 2nd level length code */
             here = lcode + here->val + (hold & ((1U << op) - 1));
             goto dolen;
-        }
-        else if (op & 32) {                     /* end-of-block */
+        } else if (op & 32) {                     /* end-of-block */
             Tracevv((stderr, "inflate:         end of block\n"));
             state->mode = TYPE;
             break;
-        }
-        else {
-            strm->msg = (char *)"invalid literal/length code";
+        } else {
+            strm->msg = (char *) "invalid literal/length code";
             state->mode = BAD;
             break;
         }
@@ -298,9 +287,9 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
     /* update state and return */
     strm->next_in = in;
     strm->next_out = out;
-    strm->avail_in = (unsigned)(in < last ? 5 + (last - in) : 5 - (in - last));
-    strm->avail_out = (unsigned)(out < end ?
-                                 257 + (end - out) : 257 - (out - end));
+    strm->avail_in = (unsigned) (in < last ? 5 + (last - in) : 5 - (in - last));
+    strm->avail_out = (unsigned) (out < end ?
+                                  257 + (end - out) : 257 - (out - end));
     state->hold = hold;
     state->bits = bits;
     return;

--- a/external/zlib/inflate.c
+++ b/external/zlib/inflate.c
@@ -93,36 +93,36 @@
 
 /* function prototypes */
 local int inflateStateCheck OF((z_streamp strm));
-local void fixedtables OF((struct inflate_state FAR *state));
-local int updatewindow OF((z_streamp strm, const unsigned char FAR *end,
-                           unsigned copy));
-#ifdef BUILDFIXED
-   void makefixed OF((void));
-#endif
-local unsigned syncsearch OF((unsigned FAR *have, const unsigned char FAR *buf,
-                              unsigned len));
 
-local int inflateStateCheck(strm)
-z_streamp strm;
-{
+local void fixedtables OF((struct inflate_state FAR *state));
+
+local int updatewindow OF((z_streamp strm, const unsigned char FAR *end,
+                                  unsigned copy));
+
+#ifdef BUILDFIXED
+void makefixed OF((void));
+#endif
+
+local unsigned syncsearch OF((unsigned FAR *have, const unsigned char FAR *buf,
+                                     unsigned len));
+
+local int inflateStateCheck(z_streamp strm) {
     struct inflate_state FAR *state;
     if (strm == Z_NULL ||
-        strm->zalloc == (alloc_func)0 || strm->zfree == (free_func)0)
+        strm->zalloc == (alloc_func) 0 || strm->zfree == (free_func) 0)
         return 1;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     if (state == Z_NULL || state->strm != strm ||
         state->mode < HEAD || state->mode > SYNC)
         return 1;
     return 0;
 }
 
-int ZEXPORT inflateResetKeep(strm)
-z_streamp strm;
-{
+int ZEXPORT inflateResetKeep(z_streamp strm) {
     struct inflate_state FAR *state;
 
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     strm->total_in = strm->total_out = state->total = 0;
     strm->msg = Z_NULL;
     if (state->wrap)        /* to support ill-conceived Java test suite */
@@ -142,29 +142,25 @@ z_streamp strm;
     return Z_OK;
 }
 
-int ZEXPORT inflateReset(strm)
-z_streamp strm;
-{
+int ZEXPORT inflateReset(z_streamp strm) {
     struct inflate_state FAR *state;
 
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     state->wsize = 0;
     state->whave = 0;
     state->wnext = 0;
     return inflateResetKeep(strm);
 }
 
-int ZEXPORT inflateReset2(strm, windowBits)
-z_streamp strm;
-int windowBits;
-{
+int ZEXPORT inflateReset2(z_streamp strm,
+                          int windowBits) {
     int wrap;
     struct inflate_state FAR *state;
 
     /* get the state */
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
 
     /* extract wrap request from windowBits parameter */
     if (windowBits < 0) {
@@ -172,8 +168,7 @@ int windowBits;
             return Z_STREAM_ERROR;
         wrap = 0;
         windowBits = -windowBits;
-    }
-    else {
+    } else {
         wrap = (windowBits >> 4) + 5;
 #ifdef GUNZIP
         if (windowBits < 48)
@@ -184,40 +179,38 @@ int windowBits;
     /* set number of window bits, free window if different */
     if (windowBits && (windowBits < 8 || windowBits > 15))
         return Z_STREAM_ERROR;
-    if (state->window != Z_NULL && state->wbits != (unsigned)windowBits) {
+    if (state->window != Z_NULL && state->wbits != (unsigned) windowBits) {
         ZFREE(strm, state->window);
         state->window = Z_NULL;
     }
 
     /* update state and reset the rest of it */
     state->wrap = wrap;
-    state->wbits = (unsigned)windowBits;
+    state->wbits = (unsigned) windowBits;
     return inflateReset(strm);
 }
 
-int ZEXPORT inflateInit2_(strm, windowBits, version, stream_size)
-z_streamp strm;
-int windowBits;
-const char *version;
-int stream_size;
-{
+int ZEXPORT inflateInit2_(z_streamp strm,
+                          int windowBits,
+                          const char *version,
+                          int stream_size) {
     int ret;
     struct inflate_state FAR *state;
 
     if (version == Z_NULL || version[0] != ZLIB_VERSION[0] ||
-        stream_size != (int)(sizeof(z_stream)))
+        stream_size != (int) (sizeof(z_stream)))
         return Z_VERSION_ERROR;
     if (strm == Z_NULL) return Z_STREAM_ERROR;
     strm->msg = Z_NULL;                 /* in case we return an error */
-    if (strm->zalloc == (alloc_func)0) {
+    if (strm->zalloc == (alloc_func) 0) {
 #ifdef Z_SOLO
         return Z_STREAM_ERROR;
 #else
         strm->zalloc = zcalloc;
-        strm->opaque = (voidpf)0;
+        strm->opaque = (voidpf) 0;
 #endif
     }
-    if (strm->zfree == (free_func)0)
+    if (strm->zfree == (free_func) 0)
 #ifdef Z_SOLO
         return Z_STREAM_ERROR;
 #else
@@ -227,7 +220,7 @@ int stream_size;
             ZALLOC(strm, 1, sizeof(struct inflate_state));
     if (state == Z_NULL) return Z_MEM_ERROR;
     Tracev((stderr, "inflate: allocated\n"));
-    strm->state = (struct internal_state FAR *)state;
+    strm->state = (struct internal_state FAR *) state;
     state->strm = strm;
     state->window = Z_NULL;
     state->mode = HEAD;     /* to pass state test in inflateReset2() */
@@ -239,32 +232,28 @@ int stream_size;
     return ret;
 }
 
-int ZEXPORT inflateInit_(strm, version, stream_size)
-z_streamp strm;
-const char *version;
-int stream_size;
-{
+int ZEXPORT inflateInit_(z_streamp strm,
+                         const char *version,
+                         int stream_size) {
     return inflateInit2_(strm, DEF_WBITS, version, stream_size);
 }
 
-int ZEXPORT inflatePrime(strm, bits, value)
-z_streamp strm;
-int bits;
-int value;
-{
+int ZEXPORT inflatePrime(z_streamp strm,
+                         int bits,
+                         int value) {
     struct inflate_state FAR *state;
 
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     if (bits < 0) {
         state->hold = 0;
         state->bits = 0;
         return Z_OK;
     }
-    if (bits > 16 || state->bits + (uInt)bits > 32) return Z_STREAM_ERROR;
+    if (bits > 16 || state->bits + (uInt) bits > 32) return Z_STREAM_ERROR;
     value &= (1L << bits) - 1;
-    state->hold += (unsigned)value << state->bits;
-    state->bits += (uInt)bits;
+    state->hold += (unsigned) value << state->bits;
+    state->bits += (uInt) bits;
     return Z_OK;
 }
 
@@ -278,9 +267,7 @@ int value;
    used for threaded applications, since the rewriting of the tables and virgin
    may not be thread-safe.
  */
-local void fixedtables(state)
-struct inflate_state FAR *state;
-{
+local void fixedtables(struct inflate_state FAR *state) {
 #ifdef BUILDFIXED
     static int virgin = 1;
     static code *lenfix, *distfix;
@@ -313,7 +300,9 @@ struct inflate_state FAR *state;
         virgin = 0;
     }
 #else /* !BUILDFIXED */
+
 #   include "inffixed.h"
+
 #endif /* BUILDFIXED */
     state->lencode = lenfix;
     state->lenbits = 9;
@@ -396,21 +385,19 @@ void makefixed()
    output will fall in the output data, making match copies simpler and faster.
    The advantage may be dependent on the size of the processor's data caches.
  */
-local int updatewindow(strm, end, copy)
-z_streamp strm;
-const Bytef *end;
-unsigned copy;
-{
+local int updatewindow(z_streamp strm,
+                       const Bytef *end,
+                       unsigned copy) {
     struct inflate_state FAR *state;
     unsigned dist;
 
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
 
     /* if it hasn't been done already, allocate space for the window */
     if (state->window == Z_NULL) {
         state->window = (unsigned char FAR *)
-                        ZALLOC(strm, 1U << state->wbits,
-                               sizeof(unsigned char));
+                ZALLOC(strm, 1U << state->wbits,
+                       sizeof(unsigned char));
         if (state->window == Z_NULL) return 1;
     }
 
@@ -426,8 +413,7 @@ unsigned copy;
         zmemcpy(state->window, end - state->wsize, state->wsize);
         state->wnext = 0;
         state->whave = state->wsize;
-    }
-    else {
+    } else {
         dist = state->wsize - state->wnext;
         if (dist > copy) dist = copy;
         zmemcpy(state->window + state->wnext, end - copy, dist);
@@ -436,8 +422,7 @@ unsigned copy;
             zmemcpy(state->window, end - copy, copy);
             state->wnext = copy;
             state->whave = state->wsize;
-        }
-        else {
+        } else {
             state->wnext += dist;
             if (state->wnext == state->wsize) state->wnext = 0;
             if (state->whave < state->wsize) state->whave += dist;
@@ -622,10 +607,8 @@ unsigned copy;
    will return Z_BUF_ERROR if it has not reached the end of the stream.
  */
 
-int ZEXPORT inflate(strm, flush)
-z_streamp strm;
-int flush;
-{
+int ZEXPORT inflate(z_streamp strm,
+                    int flush) {
     struct inflate_state FAR *state;
     z_const unsigned char FAR *next;    /* next input */
     unsigned char FAR *put;     /* next output */
@@ -643,13 +626,13 @@ int flush;
     unsigned char hbuf[4];      /* buffer for gzip header crc calculation */
 #endif
     static const unsigned short order[19] = /* permutation of code lengths */
-        {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
+            {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
 
     if (inflateStateCheck(strm) || strm->next_out == Z_NULL ||
         (strm->next_in == Z_NULL && strm->avail_in != 0))
         return Z_STREAM_ERROR;
 
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     if (state->mode == TYPE) state->mode = TYPEDO;      /* skip check */
     LOAD();
     in = have;
@@ -657,618 +640,610 @@ int flush;
     ret = Z_OK;
     for (;;)
         switch (state->mode) {
-        case HEAD:
-            if (state->wrap == 0) {
-                state->mode = TYPEDO;
-                break;
-            }
-            NEEDBITS(16);
-#ifdef GUNZIP
-            if ((state->wrap & 2) && hold == 0x8b1f) {  /* gzip header */
-                if (state->wbits == 0)
-                    state->wbits = 15;
-                state->check = crc32(0L, Z_NULL, 0);
-                CRC2(state->check, hold);
-                INITBITS();
-                state->mode = FLAGS;
-                break;
-            }
-            if (state->head != Z_NULL)
-                state->head->done = -1;
-            if (!(state->wrap & 1) ||   /* check if zlib header allowed */
-#else
-            if (
-#endif
-                ((BITS(8) << 8) + (hold >> 8)) % 31) {
-                strm->msg = (char *)"incorrect header check";
-                state->mode = BAD;
-                break;
-            }
-            if (BITS(4) != Z_DEFLATED) {
-                strm->msg = (char *)"unknown compression method";
-                state->mode = BAD;
-                break;
-            }
-            DROPBITS(4);
-            len = BITS(4) + 8;
-            if (state->wbits == 0)
-                state->wbits = len;
-            if (len > 15 || len > state->wbits) {
-                strm->msg = (char *)"invalid window size";
-                state->mode = BAD;
-                break;
-            }
-            state->dmax = 1U << len;
-            state->flags = 0;               /* indicate zlib header */
-            Tracev((stderr, "inflate:   zlib header ok\n"));
-            strm->adler = state->check = adler32(0L, Z_NULL, 0);
-            state->mode = hold & 0x200 ? DICTID : TYPE;
-            INITBITS();
-            break;
-#ifdef GUNZIP
-        case FLAGS:
-            NEEDBITS(16);
-            state->flags = (int)(hold);
-            if ((state->flags & 0xff) != Z_DEFLATED) {
-                strm->msg = (char *)"unknown compression method";
-                state->mode = BAD;
-                break;
-            }
-            if (state->flags & 0xe000) {
-                strm->msg = (char *)"unknown header flags set";
-                state->mode = BAD;
-                break;
-            }
-            if (state->head != Z_NULL)
-                state->head->text = (int)((hold >> 8) & 1);
-            if ((state->flags & 0x0200) && (state->wrap & 4))
-                CRC2(state->check, hold);
-            INITBITS();
-            state->mode = TIME;
-                /* fallthrough */
-        case TIME:
-            NEEDBITS(32);
-            if (state->head != Z_NULL)
-                state->head->time = hold;
-            if ((state->flags & 0x0200) && (state->wrap & 4))
-                CRC4(state->check, hold);
-            INITBITS();
-            state->mode = OS;
-                /* fallthrough */
-        case OS:
-            NEEDBITS(16);
-            if (state->head != Z_NULL) {
-                state->head->xflags = (int)(hold & 0xff);
-                state->head->os = (int)(hold >> 8);
-            }
-            if ((state->flags & 0x0200) && (state->wrap & 4))
-                CRC2(state->check, hold);
-            INITBITS();
-            state->mode = EXLEN;
-                /* fallthrough */
-        case EXLEN:
-            if (state->flags & 0x0400) {
+            case HEAD:
+                if (state->wrap == 0) {
+                    state->mode = TYPEDO;
+                    break;
+                }
                 NEEDBITS(16);
-                state->length = (unsigned)(hold);
+#ifdef GUNZIP
+                if ((state->wrap & 2) && hold == 0x8b1f) {  /* gzip header */
+                    if (state->wbits == 0)
+                        state->wbits = 15;
+                    state->check = crc32(0L, Z_NULL, 0);
+                    CRC2(state->check, hold);
+                    INITBITS();
+                    state->mode = FLAGS;
+                    break;
+                }
                 if (state->head != Z_NULL)
-                    state->head->extra_len = (unsigned)hold;
+                    state->head->done = -1;
+                if (!(state->wrap & 1) ||   /* check if zlib header allowed */
+                    #else
+                    if (
+                    #endif
+                    ((BITS(8) << 8) + (hold >> 8)) % 31) {
+                    strm->msg = (char *) "incorrect header check";
+                    state->mode = BAD;
+                    break;
+                }
+                if (BITS(4) != Z_DEFLATED) {
+                    strm->msg = (char *) "unknown compression method";
+                    state->mode = BAD;
+                    break;
+                }
+                DROPBITS(4);
+                len = BITS(4) + 8;
+                if (state->wbits == 0)
+                    state->wbits = len;
+                if (len > 15 || len > state->wbits) {
+                    strm->msg = (char *) "invalid window size";
+                    state->mode = BAD;
+                    break;
+                }
+                state->dmax = 1U << len;
+                state->flags = 0;               /* indicate zlib header */
+                Tracev((stderr, "inflate:   zlib header ok\n"));
+                strm->adler = state->check = adler32(0L, Z_NULL, 0);
+                state->mode = hold & 0x200 ? DICTID : TYPE;
+                INITBITS();
+                break;
+#ifdef GUNZIP
+            case FLAGS:
+                NEEDBITS(16);
+                state->flags = (int) (hold);
+                if ((state->flags & 0xff) != Z_DEFLATED) {
+                    strm->msg = (char *) "unknown compression method";
+                    state->mode = BAD;
+                    break;
+                }
+                if (state->flags & 0xe000) {
+                    strm->msg = (char *) "unknown header flags set";
+                    state->mode = BAD;
+                    break;
+                }
+                if (state->head != Z_NULL)
+                    state->head->text = (int) ((hold >> 8) & 1);
                 if ((state->flags & 0x0200) && (state->wrap & 4))
                     CRC2(state->check, hold);
                 INITBITS();
-            }
-            else if (state->head != Z_NULL)
-                state->head->extra = Z_NULL;
-            state->mode = EXTRA;
+                state->mode = TIME;
                 /* fallthrough */
-        case EXTRA:
-            if (state->flags & 0x0400) {
-                copy = state->length;
-                if (copy > have) copy = have;
-                if (copy) {
-                    if (state->head != Z_NULL &&
-                        state->head->extra != Z_NULL &&
-                        (len = state->head->extra_len - state->length) <
+            case TIME:
+                NEEDBITS(32);
+                if (state->head != Z_NULL)
+                    state->head->time = hold;
+                if ((state->flags & 0x0200) && (state->wrap & 4))
+                    CRC4(state->check, hold);
+                INITBITS();
+                state->mode = OS;
+                /* fallthrough */
+            case OS:
+                NEEDBITS(16);
+                if (state->head != Z_NULL) {
+                    state->head->xflags = (int) (hold & 0xff);
+                    state->head->os = (int) (hold >> 8);
+                }
+                if ((state->flags & 0x0200) && (state->wrap & 4))
+                    CRC2(state->check, hold);
+                INITBITS();
+                state->mode = EXLEN;
+                /* fallthrough */
+            case EXLEN:
+                if (state->flags & 0x0400) {
+                    NEEDBITS(16);
+                    state->length = (unsigned) (hold);
+                    if (state->head != Z_NULL)
+                        state->head->extra_len = (unsigned) hold;
+                    if ((state->flags & 0x0200) && (state->wrap & 4))
+                        CRC2(state->check, hold);
+                    INITBITS();
+                } else if (state->head != Z_NULL)
+                    state->head->extra = Z_NULL;
+                state->mode = EXTRA;
+                /* fallthrough */
+            case EXTRA:
+                if (state->flags & 0x0400) {
+                    copy = state->length;
+                    if (copy > have) copy = have;
+                    if (copy) {
+                        if (state->head != Z_NULL &&
+                            state->head->extra != Z_NULL &&
+                            (len = state->head->extra_len - state->length) <
                             state->head->extra_max) {
-                        zmemcpy(state->head->extra + len, next,
-                                len + copy > state->head->extra_max ?
-                                state->head->extra_max - len : copy);
+                            zmemcpy(state->head->extra + len, next,
+                                    len + copy > state->head->extra_max ?
+                                    state->head->extra_max - len : copy);
+                        }
+                        if ((state->flags & 0x0200) && (state->wrap & 4))
+                            state->check = crc32(state->check, next, copy);
+                        have -= copy;
+                        next += copy;
+                        state->length -= copy;
                     }
+                    if (state->length) goto inf_leave;
+                }
+                state->length = 0;
+                state->mode = NAME;
+                /* fallthrough */
+            case NAME:
+                if (state->flags & 0x0800) {
+                    if (have == 0) goto inf_leave;
+                    copy = 0;
+                    do {
+                        len = (unsigned) (next[copy++]);
+                        if (state->head != Z_NULL &&
+                            state->head->name != Z_NULL &&
+                            state->length < state->head->name_max)
+                            state->head->name[state->length++] = (Bytef) len;
+                    } while (len && copy < have);
                     if ((state->flags & 0x0200) && (state->wrap & 4))
                         state->check = crc32(state->check, next, copy);
                     have -= copy;
                     next += copy;
-                    state->length -= copy;
-                }
-                if (state->length) goto inf_leave;
-            }
-            state->length = 0;
-            state->mode = NAME;
+                    if (len) goto inf_leave;
+                } else if (state->head != Z_NULL)
+                    state->head->name = Z_NULL;
+                state->length = 0;
+                state->mode = COMMENT;
                 /* fallthrough */
-        case NAME:
-            if (state->flags & 0x0800) {
-                if (have == 0) goto inf_leave;
-                copy = 0;
-                do {
-                    len = (unsigned)(next[copy++]);
-                    if (state->head != Z_NULL &&
-                            state->head->name != Z_NULL &&
-                            state->length < state->head->name_max)
-                        state->head->name[state->length++] = (Bytef)len;
-                } while (len && copy < have);
-                if ((state->flags & 0x0200) && (state->wrap & 4))
-                    state->check = crc32(state->check, next, copy);
-                have -= copy;
-                next += copy;
-                if (len) goto inf_leave;
-            }
-            else if (state->head != Z_NULL)
-                state->head->name = Z_NULL;
-            state->length = 0;
-            state->mode = COMMENT;
-                /* fallthrough */
-        case COMMENT:
-            if (state->flags & 0x1000) {
-                if (have == 0) goto inf_leave;
-                copy = 0;
-                do {
-                    len = (unsigned)(next[copy++]);
-                    if (state->head != Z_NULL &&
+            case COMMENT:
+                if (state->flags & 0x1000) {
+                    if (have == 0) goto inf_leave;
+                    copy = 0;
+                    do {
+                        len = (unsigned) (next[copy++]);
+                        if (state->head != Z_NULL &&
                             state->head->comment != Z_NULL &&
                             state->length < state->head->comm_max)
-                        state->head->comment[state->length++] = (Bytef)len;
-                } while (len && copy < have);
-                if ((state->flags & 0x0200) && (state->wrap & 4))
-                    state->check = crc32(state->check, next, copy);
-                have -= copy;
-                next += copy;
-                if (len) goto inf_leave;
-            }
-            else if (state->head != Z_NULL)
-                state->head->comment = Z_NULL;
-            state->mode = HCRC;
+                            state->head->comment[state->length++] = (Bytef) len;
+                    } while (len && copy < have);
+                    if ((state->flags & 0x0200) && (state->wrap & 4))
+                        state->check = crc32(state->check, next, copy);
+                    have -= copy;
+                    next += copy;
+                    if (len) goto inf_leave;
+                } else if (state->head != Z_NULL)
+                    state->head->comment = Z_NULL;
+                state->mode = HCRC;
                 /* fallthrough */
-        case HCRC:
-            if (state->flags & 0x0200) {
-                NEEDBITS(16);
-                if ((state->wrap & 4) && hold != (state->check & 0xffff)) {
-                    strm->msg = (char *)"header crc mismatch";
-                    state->mode = BAD;
-                    break;
-                }
-                INITBITS();
-            }
-            if (state->head != Z_NULL) {
-                state->head->hcrc = (int)((state->flags >> 9) & 1);
-                state->head->done = 1;
-            }
-            strm->adler = state->check = crc32(0L, Z_NULL, 0);
-            state->mode = TYPE;
-            break;
-#endif
-        case DICTID:
-            NEEDBITS(32);
-            strm->adler = state->check = ZSWAP32(hold);
-            INITBITS();
-            state->mode = DICT;
-                /* fallthrough */
-        case DICT:
-            if (state->havedict == 0) {
-                RESTORE();
-                return Z_NEED_DICT;
-            }
-            strm->adler = state->check = adler32(0L, Z_NULL, 0);
-            state->mode = TYPE;
-                /* fallthrough */
-        case TYPE:
-            if (flush == Z_BLOCK || flush == Z_TREES) goto inf_leave;
-                /* fallthrough */
-        case TYPEDO:
-            if (state->last) {
-                BYTEBITS();
-                state->mode = CHECK;
-                break;
-            }
-            NEEDBITS(3);
-            state->last = BITS(1);
-            DROPBITS(1);
-            switch (BITS(2)) {
-            case 0:                             /* stored block */
-                Tracev((stderr, "inflate:     stored block%s\n",
-                        state->last ? " (last)" : ""));
-                state->mode = STORED;
-                break;
-            case 1:                             /* fixed block */
-                fixedtables(state);
-                Tracev((stderr, "inflate:     fixed codes block%s\n",
-                        state->last ? " (last)" : ""));
-                state->mode = LEN_;             /* decode codes */
-                if (flush == Z_TREES) {
-                    DROPBITS(2);
-                    goto inf_leave;
-                }
-                break;
-            case 2:                             /* dynamic block */
-                Tracev((stderr, "inflate:     dynamic codes block%s\n",
-                        state->last ? " (last)" : ""));
-                state->mode = TABLE;
-                break;
-            case 3:
-                strm->msg = (char *)"invalid block type";
-                state->mode = BAD;
-            }
-            DROPBITS(2);
-            break;
-        case STORED:
-            BYTEBITS();                         /* go to byte boundary */
-            NEEDBITS(32);
-            if ((hold & 0xffff) != ((hold >> 16) ^ 0xffff)) {
-                strm->msg = (char *)"invalid stored block lengths";
-                state->mode = BAD;
-                break;
-            }
-            state->length = (unsigned)hold & 0xffff;
-            Tracev((stderr, "inflate:       stored length %u\n",
-                    state->length));
-            INITBITS();
-            state->mode = COPY_;
-            if (flush == Z_TREES) goto inf_leave;
-                /* fallthrough */
-        case COPY_:
-            state->mode = COPY;
-                /* fallthrough */
-        case COPY:
-            copy = state->length;
-            if (copy) {
-                if (copy > have) copy = have;
-                if (copy > left) copy = left;
-                if (copy == 0) goto inf_leave;
-                zmemcpy(put, next, copy);
-                have -= copy;
-                next += copy;
-                left -= copy;
-                put += copy;
-                state->length -= copy;
-                break;
-            }
-            Tracev((stderr, "inflate:       stored end\n"));
-            state->mode = TYPE;
-            break;
-        case TABLE:
-            NEEDBITS(14);
-            state->nlen = BITS(5) + 257;
-            DROPBITS(5);
-            state->ndist = BITS(5) + 1;
-            DROPBITS(5);
-            state->ncode = BITS(4) + 4;
-            DROPBITS(4);
-#ifndef PKZIP_BUG_WORKAROUND
-            if (state->nlen > 286 || state->ndist > 30) {
-                strm->msg = (char *)"too many length or distance symbols";
-                state->mode = BAD;
-                break;
-            }
-#endif
-            Tracev((stderr, "inflate:       table sizes ok\n"));
-            state->have = 0;
-            state->mode = LENLENS;
-                /* fallthrough */
-        case LENLENS:
-            while (state->have < state->ncode) {
-                NEEDBITS(3);
-                state->lens[order[state->have++]] = (unsigned short)BITS(3);
-                DROPBITS(3);
-            }
-            while (state->have < 19)
-                state->lens[order[state->have++]] = 0;
-            state->next = state->codes;
-            state->lencode = (const code FAR *)(state->next);
-            state->lenbits = 7;
-            ret = inflate_table(CODES, state->lens, 19, &(state->next),
-                                &(state->lenbits), state->work);
-            if (ret) {
-                strm->msg = (char *)"invalid code lengths set";
-                state->mode = BAD;
-                break;
-            }
-            Tracev((stderr, "inflate:       code lengths ok\n"));
-            state->have = 0;
-            state->mode = CODELENS;
-                /* fallthrough */
-        case CODELENS:
-            while (state->have < state->nlen + state->ndist) {
-                for (;;) {
-                    here = state->lencode[BITS(state->lenbits)];
-                    if ((unsigned)(here.bits) <= bits) break;
-                    PULLBYTE();
-                }
-                if (here.val < 16) {
-                    DROPBITS(here.bits);
-                    state->lens[state->have++] = here.val;
-                }
-                else {
-                    if (here.val == 16) {
-                        NEEDBITS(here.bits + 2);
-                        DROPBITS(here.bits);
-                        if (state->have == 0) {
-                            strm->msg = (char *)"invalid bit length repeat";
-                            state->mode = BAD;
-                            break;
-                        }
-                        len = state->lens[state->have - 1];
-                        copy = 3 + BITS(2);
-                        DROPBITS(2);
-                    }
-                    else if (here.val == 17) {
-                        NEEDBITS(here.bits + 3);
-                        DROPBITS(here.bits);
-                        len = 0;
-                        copy = 3 + BITS(3);
-                        DROPBITS(3);
-                    }
-                    else {
-                        NEEDBITS(here.bits + 7);
-                        DROPBITS(here.bits);
-                        len = 0;
-                        copy = 11 + BITS(7);
-                        DROPBITS(7);
-                    }
-                    if (state->have + copy > state->nlen + state->ndist) {
-                        strm->msg = (char *)"invalid bit length repeat";
+            case HCRC:
+                if (state->flags & 0x0200) {
+                    NEEDBITS(16);
+                    if ((state->wrap & 4) && hold != (state->check & 0xffff)) {
+                        strm->msg = (char *) "header crc mismatch";
                         state->mode = BAD;
                         break;
                     }
-                    while (copy--)
-                        state->lens[state->have++] = (unsigned short)len;
+                    INITBITS();
                 }
-            }
-
-            /* handle error breaks in while */
-            if (state->mode == BAD) break;
-
-            /* check for end-of-block code (better have one) */
-            if (state->lens[256] == 0) {
-                strm->msg = (char *)"invalid code -- missing end-of-block";
-                state->mode = BAD;
-                break;
-            }
-
-            /* build code tables -- note: do not change the lenbits or distbits
-               values here (9 and 6) without reading the comments in inftrees.h
-               concerning the ENOUGH constants, which depend on those values */
-            state->next = state->codes;
-            state->lencode = (const code FAR *)(state->next);
-            state->lenbits = 9;
-            ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
-                                &(state->lenbits), state->work);
-            if (ret) {
-                strm->msg = (char *)"invalid literal/lengths set";
-                state->mode = BAD;
-                break;
-            }
-            state->distcode = (const code FAR *)(state->next);
-            state->distbits = 6;
-            ret = inflate_table(DISTS, state->lens + state->nlen, state->ndist,
-                            &(state->next), &(state->distbits), state->work);
-            if (ret) {
-                strm->msg = (char *)"invalid distances set";
-                state->mode = BAD;
-                break;
-            }
-            Tracev((stderr, "inflate:       codes ok\n"));
-            state->mode = LEN_;
-            if (flush == Z_TREES) goto inf_leave;
-                /* fallthrough */
-        case LEN_:
-            state->mode = LEN;
-                /* fallthrough */
-        case LEN:
-            if (have >= 6 && left >= 258) {
-                RESTORE();
-                inflate_fast(strm, out);
-                LOAD();
-                if (state->mode == TYPE)
-                    state->back = -1;
-                break;
-            }
-            state->back = 0;
-            for (;;) {
-                here = state->lencode[BITS(state->lenbits)];
-                if ((unsigned)(here.bits) <= bits) break;
-                PULLBYTE();
-            }
-            if (here.op && (here.op & 0xf0) == 0) {
-                last = here;
-                for (;;) {
-                    here = state->lencode[last.val +
-                            (BITS(last.bits + last.op) >> last.bits)];
-                    if ((unsigned)(last.bits + here.bits) <= bits) break;
-                    PULLBYTE();
+                if (state->head != Z_NULL) {
+                    state->head->hcrc = (int) ((state->flags >> 9) & 1);
+                    state->head->done = 1;
                 }
-                DROPBITS(last.bits);
-                state->back += last.bits;
-            }
-            DROPBITS(here.bits);
-            state->back += here.bits;
-            state->length = (unsigned)here.val;
-            if ((int)(here.op) == 0) {
-                Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
-                        "inflate:         literal '%c'\n" :
-                        "inflate:         literal 0x%02x\n", here.val));
-                state->mode = LIT;
-                break;
-            }
-            if (here.op & 32) {
-                Tracevv((stderr, "inflate:         end of block\n"));
-                state->back = -1;
+                strm->adler = state->check = crc32(0L, Z_NULL, 0);
                 state->mode = TYPE;
                 break;
-            }
-            if (here.op & 64) {
-                strm->msg = (char *)"invalid literal/length code";
-                state->mode = BAD;
+#endif
+            case DICTID:
+                NEEDBITS(32);
+                strm->adler = state->check = ZSWAP32(hold);
+                INITBITS();
+                state->mode = DICT;
+                /* fallthrough */
+            case DICT:
+                if (state->havedict == 0) {
+                    RESTORE();
+                    return Z_NEED_DICT;
+                }
+                strm->adler = state->check = adler32(0L, Z_NULL, 0);
+                state->mode = TYPE;
+                /* fallthrough */
+            case TYPE:
+                if (flush == Z_BLOCK || flush == Z_TREES) goto inf_leave;
+                /* fallthrough */
+            case TYPEDO:
+                if (state->last) {
+                    BYTEBITS();
+                    state->mode = CHECK;
+                    break;
+                }
+                NEEDBITS(3);
+                state->last = BITS(1);
+                DROPBITS(1);
+                switch (BITS(2)) {
+                    case 0:                             /* stored block */
+                        Tracev((stderr, "inflate:     stored block%s\n",
+                                state->last ? " (last)" : ""));
+                        state->mode = STORED;
+                        break;
+                    case 1:                             /* fixed block */
+                        fixedtables(state);
+                        Tracev((stderr, "inflate:     fixed codes block%s\n",
+                                state->last ? " (last)" : ""));
+                        state->mode = LEN_;             /* decode codes */
+                        if (flush == Z_TREES) {
+                            DROPBITS(2);
+                            goto inf_leave;
+                        }
+                        break;
+                    case 2:                             /* dynamic block */
+                        Tracev((stderr, "inflate:     dynamic codes block%s\n",
+                                state->last ? " (last)" : ""));
+                        state->mode = TABLE;
+                        break;
+                    case 3:
+                        strm->msg = (char *) "invalid block type";
+                        state->mode = BAD;
+                }
+                DROPBITS(2);
                 break;
-            }
-            state->extra = (unsigned)(here.op) & 15;
-            state->mode = LENEXT;
+            case STORED:
+                BYTEBITS();                         /* go to byte boundary */
+                NEEDBITS(32);
+                if ((hold & 0xffff) != ((hold >> 16) ^ 0xffff)) {
+                    strm->msg = (char *) "invalid stored block lengths";
+                    state->mode = BAD;
+                    break;
+                }
+                state->length = (unsigned) hold & 0xffff;
+                Tracev((stderr, "inflate:       stored length %u\n",
+                        state->length));
+                INITBITS();
+                state->mode = COPY_;
+                if (flush == Z_TREES) goto inf_leave;
                 /* fallthrough */
-        case LENEXT:
-            if (state->extra) {
-                NEEDBITS(state->extra);
-                state->length += BITS(state->extra);
-                DROPBITS(state->extra);
-                state->back += state->extra;
-            }
-            Tracevv((stderr, "inflate:         length %u\n", state->length));
-            state->was = state->length;
-            state->mode = DIST;
+            case COPY_:
+                state->mode = COPY;
                 /* fallthrough */
-        case DIST:
-            for (;;) {
-                here = state->distcode[BITS(state->distbits)];
-                if ((unsigned)(here.bits) <= bits) break;
-                PULLBYTE();
-            }
-            if ((here.op & 0xf0) == 0) {
-                last = here;
+            case COPY:
+                copy = state->length;
+                if (copy) {
+                    if (copy > have) copy = have;
+                    if (copy > left) copy = left;
+                    if (copy == 0) goto inf_leave;
+                    zmemcpy(put, next, copy);
+                    have -= copy;
+                    next += copy;
+                    left -= copy;
+                    put += copy;
+                    state->length -= copy;
+                    break;
+                }
+                Tracev((stderr, "inflate:       stored end\n"));
+                state->mode = TYPE;
+                break;
+            case TABLE:
+                NEEDBITS(14);
+                state->nlen = BITS(5) + 257;
+                DROPBITS(5);
+                state->ndist = BITS(5) + 1;
+                DROPBITS(5);
+                state->ncode = BITS(4) + 4;
+                DROPBITS(4);
+#ifndef PKZIP_BUG_WORKAROUND
+                if (state->nlen > 286 || state->ndist > 30) {
+                    strm->msg = (char *) "too many length or distance symbols";
+                    state->mode = BAD;
+                    break;
+                }
+#endif
+                Tracev((stderr, "inflate:       table sizes ok\n"));
+                state->have = 0;
+                state->mode = LENLENS;
+                /* fallthrough */
+            case LENLENS:
+                while (state->have < state->ncode) {
+                    NEEDBITS(3);
+                    state->lens[order[state->have++]] = (unsigned short) BITS(3);
+                    DROPBITS(3);
+                }
+                while (state->have < 19)
+                    state->lens[order[state->have++]] = 0;
+                state->next = state->codes;
+                state->lencode = (const code FAR *) (state->next);
+                state->lenbits = 7;
+                ret = inflate_table(CODES, state->lens, 19, &(state->next),
+                                    &(state->lenbits), state->work);
+                if (ret) {
+                    strm->msg = (char *) "invalid code lengths set";
+                    state->mode = BAD;
+                    break;
+                }
+                Tracev((stderr, "inflate:       code lengths ok\n"));
+                state->have = 0;
+                state->mode = CODELENS;
+                /* fallthrough */
+            case CODELENS:
+                while (state->have < state->nlen + state->ndist) {
+                    for (;;) {
+                        here = state->lencode[BITS(state->lenbits)];
+                        if ((unsigned) (here.bits) <= bits) break;
+                        PULLBYTE();
+                    }
+                    if (here.val < 16) {
+                        DROPBITS(here.bits);
+                        state->lens[state->have++] = here.val;
+                    } else {
+                        if (here.val == 16) {
+                            NEEDBITS(here.bits + 2);
+                            DROPBITS(here.bits);
+                            if (state->have == 0) {
+                                strm->msg = (char *) "invalid bit length repeat";
+                                state->mode = BAD;
+                                break;
+                            }
+                            len = state->lens[state->have - 1];
+                            copy = 3 + BITS(2);
+                            DROPBITS(2);
+                        } else if (here.val == 17) {
+                            NEEDBITS(here.bits + 3);
+                            DROPBITS(here.bits);
+                            len = 0;
+                            copy = 3 + BITS(3);
+                            DROPBITS(3);
+                        } else {
+                            NEEDBITS(here.bits + 7);
+                            DROPBITS(here.bits);
+                            len = 0;
+                            copy = 11 + BITS(7);
+                            DROPBITS(7);
+                        }
+                        if (state->have + copy > state->nlen + state->ndist) {
+                            strm->msg = (char *) "invalid bit length repeat";
+                            state->mode = BAD;
+                            break;
+                        }
+                        while (copy--)
+                            state->lens[state->have++] = (unsigned short) len;
+                    }
+                }
+
+                /* handle error breaks in while */
+                if (state->mode == BAD) break;
+
+                /* check for end-of-block code (better have one) */
+                if (state->lens[256] == 0) {
+                    strm->msg = (char *) "invalid code -- missing end-of-block";
+                    state->mode = BAD;
+                    break;
+                }
+
+                /* build code tables -- note: do not change the lenbits or distbits
+                   values here (9 and 6) without reading the comments in inftrees.h
+                   concerning the ENOUGH constants, which depend on those values */
+                state->next = state->codes;
+                state->lencode = (const code FAR *) (state->next);
+                state->lenbits = 9;
+                ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
+                                    &(state->lenbits), state->work);
+                if (ret) {
+                    strm->msg = (char *) "invalid literal/lengths set";
+                    state->mode = BAD;
+                    break;
+                }
+                state->distcode = (const code FAR *) (state->next);
+                state->distbits = 6;
+                ret = inflate_table(DISTS, state->lens + state->nlen, state->ndist,
+                                    &(state->next), &(state->distbits), state->work);
+                if (ret) {
+                    strm->msg = (char *) "invalid distances set";
+                    state->mode = BAD;
+                    break;
+                }
+                Tracev((stderr, "inflate:       codes ok\n"));
+                state->mode = LEN_;
+                if (flush == Z_TREES) goto inf_leave;
+                /* fallthrough */
+            case LEN_:
+                state->mode = LEN;
+                /* fallthrough */
+            case LEN:
+                if (have >= 6 && left >= 258) {
+                    RESTORE();
+                    inflate_fast(strm, out);
+                    LOAD();
+                    if (state->mode == TYPE)
+                        state->back = -1;
+                    break;
+                }
+                state->back = 0;
                 for (;;) {
-                    here = state->distcode[last.val +
-                            (BITS(last.bits + last.op) >> last.bits)];
-                    if ((unsigned)(last.bits + here.bits) <= bits) break;
+                    here = state->lencode[BITS(state->lenbits)];
+                    if ((unsigned) (here.bits) <= bits) break;
                     PULLBYTE();
                 }
-                DROPBITS(last.bits);
-                state->back += last.bits;
-            }
-            DROPBITS(here.bits);
-            state->back += here.bits;
-            if (here.op & 64) {
-                strm->msg = (char *)"invalid distance code";
-                state->mode = BAD;
-                break;
-            }
-            state->offset = (unsigned)here.val;
-            state->extra = (unsigned)(here.op) & 15;
-            state->mode = DISTEXT;
+                if (here.op && (here.op & 0xf0) == 0) {
+                    last = here;
+                    for (;;) {
+                        here = state->lencode[last.val +
+                                              (BITS(last.bits + last.op) >> last.bits)];
+                        if ((unsigned) (last.bits + here.bits) <= bits) break;
+                        PULLBYTE();
+                    }
+                    DROPBITS(last.bits);
+                    state->back += last.bits;
+                }
+                DROPBITS(here.bits);
+                state->back += here.bits;
+                state->length = (unsigned) here.val;
+                if ((int) (here.op) == 0) {
+                    Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
+                                     "inflate:         literal '%c'\n" :
+                                     "inflate:         literal 0x%02x\n", here.val));
+                    state->mode = LIT;
+                    break;
+                }
+                if (here.op & 32) {
+                    Tracevv((stderr, "inflate:         end of block\n"));
+                    state->back = -1;
+                    state->mode = TYPE;
+                    break;
+                }
+                if (here.op & 64) {
+                    strm->msg = (char *) "invalid literal/length code";
+                    state->mode = BAD;
+                    break;
+                }
+                state->extra = (unsigned) (here.op) & 15;
+                state->mode = LENEXT;
                 /* fallthrough */
-        case DISTEXT:
-            if (state->extra) {
-                NEEDBITS(state->extra);
-                state->offset += BITS(state->extra);
-                DROPBITS(state->extra);
-                state->back += state->extra;
-            }
+            case LENEXT:
+                if (state->extra) {
+                    NEEDBITS(state->extra);
+                    state->length += BITS(state->extra);
+                    DROPBITS(state->extra);
+                    state->back += state->extra;
+                }
+                Tracevv((stderr, "inflate:         length %u\n", state->length));
+                state->was = state->length;
+                state->mode = DIST;
+                /* fallthrough */
+            case DIST:
+                for (;;) {
+                    here = state->distcode[BITS(state->distbits)];
+                    if ((unsigned) (here.bits) <= bits) break;
+                    PULLBYTE();
+                }
+                if ((here.op & 0xf0) == 0) {
+                    last = here;
+                    for (;;) {
+                        here = state->distcode[last.val +
+                                               (BITS(last.bits + last.op) >> last.bits)];
+                        if ((unsigned) (last.bits + here.bits) <= bits) break;
+                        PULLBYTE();
+                    }
+                    DROPBITS(last.bits);
+                    state->back += last.bits;
+                }
+                DROPBITS(here.bits);
+                state->back += here.bits;
+                if (here.op & 64) {
+                    strm->msg = (char *) "invalid distance code";
+                    state->mode = BAD;
+                    break;
+                }
+                state->offset = (unsigned) here.val;
+                state->extra = (unsigned) (here.op) & 15;
+                state->mode = DISTEXT;
+                /* fallthrough */
+            case DISTEXT:
+                if (state->extra) {
+                    NEEDBITS(state->extra);
+                    state->offset += BITS(state->extra);
+                    DROPBITS(state->extra);
+                    state->back += state->extra;
+                }
 #ifdef INFLATE_STRICT
-            if (state->offset > state->dmax) {
-                strm->msg = (char *)"invalid distance too far back";
-                state->mode = BAD;
-                break;
-            }
-#endif
-            Tracevv((stderr, "inflate:         distance %u\n", state->offset));
-            state->mode = MATCH;
-                /* fallthrough */
-        case MATCH:
-            if (left == 0) goto inf_leave;
-            copy = out - left;
-            if (state->offset > copy) {         /* copy from window */
-                copy = state->offset - copy;
-                if (copy > state->whave) {
-                    if (state->sane) {
+                    if (state->offset > state->dmax) {
                         strm->msg = (char *)"invalid distance too far back";
                         state->mode = BAD;
                         break;
                     }
+#endif
+                Tracevv((stderr, "inflate:         distance %u\n", state->offset));
+                state->mode = MATCH;
+                /* fallthrough */
+            case MATCH:
+                if (left == 0) goto inf_leave;
+                copy = out - left;
+                if (state->offset > copy) {         /* copy from window */
+                    copy = state->offset - copy;
+                    if (copy > state->whave) {
+                        if (state->sane) {
+                            strm->msg = (char *) "invalid distance too far back";
+                            state->mode = BAD;
+                            break;
+                        }
 #ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
-                    Trace((stderr, "inflate.c too far\n"));
-                    copy -= state->whave;
+                        Trace((stderr, "inflate.c too far\n"));
+                        copy -= state->whave;
+                        if (copy > state->length) copy = state->length;
+                        if (copy > left) copy = left;
+                        left -= copy;
+                        state->length -= copy;
+                        do {
+                            *put++ = 0;
+                        } while (--copy);
+                        if (state->length == 0) state->mode = LEN;
+                        break;
+#endif
+                    }
+                    if (copy > state->wnext) {
+                        copy -= state->wnext;
+                        from = state->window + (state->wsize - copy);
+                    } else
+                        from = state->window + (state->wnext - copy);
                     if (copy > state->length) copy = state->length;
-                    if (copy > left) copy = left;
-                    left -= copy;
-                    state->length -= copy;
-                    do {
-                        *put++ = 0;
-                    } while (--copy);
-                    if (state->length == 0) state->mode = LEN;
-                    break;
-#endif
+                } else {                              /* copy from output */
+                    from = put - state->offset;
+                    copy = state->length;
                 }
-                if (copy > state->wnext) {
-                    copy -= state->wnext;
-                    from = state->window + (state->wsize - copy);
-                }
-                else
-                    from = state->window + (state->wnext - copy);
-                if (copy > state->length) copy = state->length;
-            }
-            else {                              /* copy from output */
-                from = put - state->offset;
-                copy = state->length;
-            }
-            if (copy > left) copy = left;
-            left -= copy;
-            state->length -= copy;
-            do {
-                *put++ = *from++;
-            } while (--copy);
-            if (state->length == 0) state->mode = LEN;
-            break;
-        case LIT:
-            if (left == 0) goto inf_leave;
-            *put++ = (unsigned char)(state->length);
-            left--;
-            state->mode = LEN;
-            break;
-        case CHECK:
-            if (state->wrap) {
-                NEEDBITS(32);
-                out -= left;
-                strm->total_out += out;
-                state->total += out;
-                if ((state->wrap & 4) && out)
-                    strm->adler = state->check =
-                        UPDATE_CHECK(state->check, put - out, out);
-                out = left;
-                if ((state->wrap & 4) && (
+                if (copy > left) copy = left;
+                left -= copy;
+                state->length -= copy;
+                do {
+                    *put++ = *from++;
+                } while (--copy);
+                if (state->length == 0) state->mode = LEN;
+                break;
+            case LIT:
+                if (left == 0) goto inf_leave;
+                *put++ = (unsigned char) (state->length);
+                left--;
+                state->mode = LEN;
+                break;
+            case CHECK:
+                if (state->wrap) {
+                    NEEDBITS(32);
+                    out -= left;
+                    strm->total_out += out;
+                    state->total += out;
+                    if ((state->wrap & 4) && out)
+                        strm->adler = state->check =
+                                UPDATE_CHECK(state->check, put - out, out);
+                    out = left;
+                    if ((state->wrap & 4) && (
 #ifdef GUNZIP
-                     state->flags ? hold :
-#endif
-                     ZSWAP32(hold)) != state->check) {
-                    strm->msg = (char *)"incorrect data check";
-                    state->mode = BAD;
-                    break;
+                                                     state->flags ? hold :
+                                                     #endif
+                                                     ZSWAP32(hold)) != state->check) {
+                        strm->msg = (char *) "incorrect data check";
+                        state->mode = BAD;
+                        break;
+                    }
+                    INITBITS();
+                    Tracev((stderr, "inflate:   check matches trailer\n"));
                 }
-                INITBITS();
-                Tracev((stderr, "inflate:   check matches trailer\n"));
-            }
 #ifdef GUNZIP
-            state->mode = LENGTH;
+                state->mode = LENGTH;
                 /* fallthrough */
-        case LENGTH:
-            if (state->wrap && state->flags) {
-                NEEDBITS(32);
-                if ((state->wrap & 4) && hold != (state->total & 0xffffffff)) {
-                    strm->msg = (char *)"incorrect length check";
-                    state->mode = BAD;
-                    break;
+            case LENGTH:
+                if (state->wrap && state->flags) {
+                    NEEDBITS(32);
+                    if ((state->wrap & 4) && hold != (state->total & 0xffffffff)) {
+                        strm->msg = (char *) "incorrect length check";
+                        state->mode = BAD;
+                        break;
+                    }
+                    INITBITS();
+                    Tracev((stderr, "inflate:   length matches trailer\n"));
                 }
-                INITBITS();
-                Tracev((stderr, "inflate:   length matches trailer\n"));
-            }
 #endif
-            state->mode = DONE;
+                state->mode = DONE;
                 /* fallthrough */
-        case DONE:
-            ret = Z_STREAM_END;
-            goto inf_leave;
-        case BAD:
-            ret = Z_DATA_ERROR;
-            goto inf_leave;
-        case MEM:
-            return Z_MEM_ERROR;
-        case SYNC:
+            case DONE:
+                ret = Z_STREAM_END;
+                goto inf_leave;
+            case BAD:
+                ret = Z_DATA_ERROR;
+                goto inf_leave;
+            case MEM:
+                return Z_MEM_ERROR;
+            case SYNC:
                 /* fallthrough */
-        default:
-            return Z_STREAM_ERROR;
+            default:
+                return Z_STREAM_ERROR;
         }
 
     /*
@@ -1277,10 +1252,10 @@ int flush;
        error.  Call updatewindow() to create and/or update the window state.
        Note: a memory error from inflate() is non-recoverable.
      */
-  inf_leave:
+    inf_leave:
     RESTORE();
     if (state->wsize || (out != strm->avail_out && state->mode < BAD &&
-            (state->mode < CHECK || flush != Z_FINISH)))
+                         (state->mode < CHECK || flush != Z_FINISH)))
         if (updatewindow(strm, strm->next_out, out - strm->avail_out)) {
             state->mode = MEM;
             return Z_MEM_ERROR;
@@ -1292,8 +1267,8 @@ int flush;
     state->total += out;
     if ((state->wrap & 4) && out)
         strm->adler = state->check =
-            UPDATE_CHECK(state->check, strm->next_out - out, out);
-    strm->data_type = (int)state->bits + (state->last ? 64 : 0) +
+                UPDATE_CHECK(state->check, strm->next_out - out, out);
+    strm->data_type = (int) state->bits + (state->last ? 64 : 0) +
                       (state->mode == TYPE ? 128 : 0) +
                       (state->mode == LEN_ || state->mode == COPY_ ? 256 : 0);
     if (((in == 0 && out == 0) || flush == Z_FINISH) && ret == Z_OK)
@@ -1301,13 +1276,11 @@ int flush;
     return ret;
 }
 
-int ZEXPORT inflateEnd(strm)
-z_streamp strm;
-{
+int ZEXPORT inflateEnd(z_streamp strm) {
     struct inflate_state FAR *state;
     if (inflateStateCheck(strm))
         return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     if (state->window != Z_NULL) ZFREE(strm, state->window);
     ZFREE(strm, strm->state);
     strm->state = Z_NULL;
@@ -1315,16 +1288,14 @@ z_streamp strm;
     return Z_OK;
 }
 
-int ZEXPORT inflateGetDictionary(strm, dictionary, dictLength)
-z_streamp strm;
-Bytef *dictionary;
-uInt *dictLength;
-{
+int ZEXPORT inflateGetDictionary(z_streamp strm,
+                                 Bytef *dictionary,
+                                 uInt *dictLength) {
     struct inflate_state FAR *state;
 
     /* check state */
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
 
     /* copy dictionary */
     if (state->whave && dictionary != Z_NULL) {
@@ -1338,18 +1309,16 @@ uInt *dictLength;
     return Z_OK;
 }
 
-int ZEXPORT inflateSetDictionary(strm, dictionary, dictLength)
-z_streamp strm;
-const Bytef *dictionary;
-uInt dictLength;
-{
+int ZEXPORT inflateSetDictionary(z_streamp strm,
+                                 const Bytef *dictionary,
+                                 uInt dictLength) {
     struct inflate_state FAR *state;
     unsigned long dictid;
     int ret;
 
     /* check state */
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     if (state->wrap != 0 && state->mode != DICT)
         return Z_STREAM_ERROR;
 
@@ -1373,15 +1342,13 @@ uInt dictLength;
     return Z_OK;
 }
 
-int ZEXPORT inflateGetHeader(strm, head)
-z_streamp strm;
-gz_headerp head;
-{
+int ZEXPORT inflateGetHeader(z_streamp strm,
+                             gz_headerp head) {
     struct inflate_state FAR *state;
 
     /* check state */
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     if ((state->wrap & 2) == 0) return Z_STREAM_ERROR;
 
     /* save header structure */
@@ -1401,18 +1368,16 @@ gz_headerp head;
    called again with more data and the *have state.  *have is initialized to
    zero for the first call.
  */
-local unsigned syncsearch(have, buf, len)
-unsigned FAR *have;
-const unsigned char FAR *buf;
-unsigned len;
-{
+local unsigned syncsearch(unsigned FAR *have,
+                          const unsigned char FAR *buf,
+                          unsigned len) {
     unsigned got;
     unsigned next;
 
     got = *have;
     next = 0;
     while (next < len && got < 4) {
-        if ((int)(buf[next]) == (got < 2 ? 0 : 0xff))
+        if ((int) (buf[next]) == (got < 2 ? 0 : 0xff))
             got++;
         else if (buf[next])
             got = 0;
@@ -1424,9 +1389,7 @@ unsigned len;
     return next;
 }
 
-int ZEXPORT inflateSync(strm)
-z_streamp strm;
-{
+int ZEXPORT inflateSync(z_streamp strm) {
     unsigned len;               /* number of bytes to look at or looked at */
     int flags;                  /* temporary to save header status */
     unsigned long in, out;      /* temporary to save total_in and total_out */
@@ -1435,7 +1398,7 @@ z_streamp strm;
 
     /* check parameters */
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     if (strm->avail_in == 0 && state->bits < 8) return Z_BUF_ERROR;
 
     /* if first time, start search in bit buffer */
@@ -1445,7 +1408,7 @@ z_streamp strm;
         state->bits -= state->bits & 7;
         len = 0;
         while (state->bits >= 8) {
-            buf[len++] = (unsigned char)(state->hold);
+            buf[len++] = (unsigned char) (state->hold);
             state->hold >>= 8;
             state->bits -= 8;
         }
@@ -1466,9 +1429,11 @@ z_streamp strm;
     else
         state->wrap &= ~4;  /* no point in computing a check value now */
     flags = state->flags;
-    in = strm->total_in;  out = strm->total_out;
+    in = strm->total_in;
+    out = strm->total_out;
     inflateReset(strm);
-    strm->total_in = in;  strm->total_out = out;
+    strm->total_in = in;
+    strm->total_out = out;
     state->flags = flags;
     state->mode = TYPE;
     return Z_OK;
@@ -1482,20 +1447,16 @@ z_streamp strm;
    block. When decompressing, PPP checks that at the end of input packet,
    inflate is waiting for these length bytes.
  */
-int ZEXPORT inflateSyncPoint(strm)
-z_streamp strm;
-{
+int ZEXPORT inflateSyncPoint(z_streamp strm) {
     struct inflate_state FAR *state;
 
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     return state->mode == STORED && state->bits == 0;
 }
 
-int ZEXPORT inflateCopy(dest, source)
-z_streamp dest;
-z_streamp source;
-{
+int ZEXPORT inflateCopy(z_streamp dest,
+                        z_streamp source) {
     struct inflate_state FAR *state;
     struct inflate_state FAR *copy;
     unsigned char FAR *window;
@@ -1504,16 +1465,16 @@ z_streamp source;
     /* check input */
     if (inflateStateCheck(source) || dest == Z_NULL)
         return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)source->state;
+    state = (struct inflate_state FAR *) source->state;
 
     /* allocate space */
     copy = (struct inflate_state FAR *)
-           ZALLOC(source, 1, sizeof(struct inflate_state));
+            ZALLOC(source, 1, sizeof(struct inflate_state));
     if (copy == Z_NULL) return Z_MEM_ERROR;
     window = Z_NULL;
     if (state->window != Z_NULL) {
         window = (unsigned char FAR *)
-                 ZALLOC(source, 1U << state->wbits, sizeof(unsigned char));
+                ZALLOC(source, 1U << state->wbits, sizeof(unsigned char));
         if (window == Z_NULL) {
             ZFREE(source, copy);
             return Z_MEM_ERROR;
@@ -1521,8 +1482,8 @@ z_streamp source;
     }
 
     /* copy state */
-    zmemcpy((voidpf)dest, (voidpf)source, sizeof(z_stream));
-    zmemcpy((voidpf)copy, (voidpf)state, sizeof(struct inflate_state));
+    zmemcpy((voidpf) dest, (voidpf) source, sizeof(z_stream));
+    zmemcpy((voidpf) copy, (voidpf) state, sizeof(struct inflate_state));
     copy->strm = dest;
     if (state->lencode >= state->codes &&
         state->lencode <= state->codes + ENOUGH - 1) {
@@ -1535,36 +1496,32 @@ z_streamp source;
         zmemcpy(window, state->window, wsize);
     }
     copy->window = window;
-    dest->state = (struct internal_state FAR *)copy;
+    dest->state = (struct internal_state FAR *) copy;
     return Z_OK;
 }
 
-int ZEXPORT inflateUndermine(strm, subvert)
-z_streamp strm;
-int subvert;
-{
+int ZEXPORT inflateUndermine(z_streamp strm,
+                             int subvert) {
     struct inflate_state FAR *state;
 
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
 #ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
     state->sane = !subvert;
     return Z_OK;
 #else
-    (void)subvert;
+    (void) subvert;
     state->sane = 1;
     return Z_DATA_ERROR;
 #endif
 }
 
-int ZEXPORT inflateValidate(strm, check)
-z_streamp strm;
-int check;
-{
+int ZEXPORT inflateValidate(z_streamp strm,
+                            int check) {
     struct inflate_state FAR *state;
 
     if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
-    state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *) strm->state;
     if (check && state->wrap)
         state->wrap |= 4;
     else
@@ -1572,24 +1529,20 @@ int check;
     return Z_OK;
 }
 
-long ZEXPORT inflateMark(strm)
-z_streamp strm;
-{
+long ZEXPORT inflateMark(z_streamp strm) {
     struct inflate_state FAR *state;
 
     if (inflateStateCheck(strm))
         return -(1L << 16);
-    state = (struct inflate_state FAR *)strm->state;
-    return (long)(((unsigned long)((long)state->back)) << 16) +
-        (state->mode == COPY ? state->length :
+    state = (struct inflate_state FAR *) strm->state;
+    return (long) (((unsigned long) ((long) state->back)) << 16) +
+           (state->mode == COPY ? state->length :
             (state->mode == MATCH ? state->was - state->length : 0));
 }
 
-unsigned long ZEXPORT inflateCodesUsed(strm)
-z_streamp strm;
-{
+unsigned long ZEXPORT inflateCodesUsed(z_streamp strm) {
     struct inflate_state FAR *state;
-    if (inflateStateCheck(strm)) return (unsigned long)-1;
-    state = (struct inflate_state FAR *)strm->state;
-    return (unsigned long)(state->next - state->codes);
+    if (inflateStateCheck(strm)) return (unsigned long) -1;
+    state = (struct inflate_state FAR *) strm->state;
+    return (unsigned long) (state->next - state->codes);
 }

--- a/external/zlib/inftrees.c
+++ b/external/zlib/inftrees.c
@@ -9,7 +9,7 @@
 #define MAXBITS 15
 
 const char inflate_copyright[] =
-   " inflate 1.2.13 Copyright 1995-2022 Mark Adler ";
+        " inflate 1.2.13 Copyright 1995-2022 Mark Adler ";
 /*
   If you use the zlib library in a product, an acknowledgment is welcome
   in the documentation of your product. If for some reason you cannot
@@ -29,14 +29,12 @@ const char inflate_copyright[] =
    table index bits.  It will differ if the request is greater than the
    longest code or if it is less than the shortest code.
  */
-int ZLIB_INTERNAL inflate_table(type, lens, codes, table, bits, work)
-codetype type;
-unsigned short FAR *lens;
-unsigned codes;
-code FAR * FAR *table;
-unsigned FAR *bits;
-unsigned short FAR *work;
-{
+int ZLIB_INTERNAL inflate_table(codetype type,
+                                unsigned short FAR *lens,
+                                unsigned codes,
+                                code FAR *FAR *table,
+                                unsigned FAR *bits,
+                                unsigned short FAR *work) {
     unsigned len;               /* a code's length in bits */
     unsigned sym;               /* index of code symbols */
     unsigned min, max;          /* minimum and maximum code lengths */
@@ -55,22 +53,22 @@ unsigned short FAR *work;
     const unsigned short FAR *base;     /* base value table to use */
     const unsigned short FAR *extra;    /* extra bits table to use */
     unsigned match;             /* use base and extra for symbol >= match */
-    unsigned short count[MAXBITS+1];    /* number of codes of each length */
-    unsigned short offs[MAXBITS+1];     /* offsets in table for each length */
+    unsigned short count[MAXBITS + 1];    /* number of codes of each length */
+    unsigned short offs[MAXBITS + 1];     /* offsets in table for each length */
     static const unsigned short lbase[31] = { /* Length codes 257..285 base */
-        3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31,
-        35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258, 0, 0};
+            3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31,
+            35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258, 0, 0};
     static const unsigned short lext[31] = { /* Length codes 257..285 extra */
-        16, 16, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 18, 18, 18, 18,
-        19, 19, 19, 19, 20, 20, 20, 20, 21, 21, 21, 21, 16, 194, 65};
+            16, 16, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 18, 18, 18, 18,
+            19, 19, 19, 19, 20, 20, 20, 20, 21, 21, 21, 21, 16, 194, 65};
     static const unsigned short dbase[32] = { /* Distance codes 0..29 base */
-        1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193,
-        257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145,
-        8193, 12289, 16385, 24577, 0, 0};
+            1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193,
+            257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145,
+            8193, 12289, 16385, 24577, 0, 0};
     static const unsigned short dext[32] = { /* Distance codes 0..29 extra */
-        16, 16, 16, 16, 17, 17, 18, 18, 19, 19, 20, 20, 21, 21, 22, 22,
-        23, 23, 24, 24, 25, 25, 26, 26, 27, 27,
-        28, 28, 29, 29, 64, 64};
+            16, 16, 16, 16, 17, 17, 18, 18, 19, 19, 20, 20, 21, 21, 22, 22,
+            23, 23, 24, 24, 25, 25, 26, 26, 27, 27,
+            28, 28, 29, 29, 64, 64};
 
     /*
        Process a set of code lengths to create a canonical Huffman code.  The
@@ -115,9 +113,9 @@ unsigned short FAR *work;
         if (count[max] != 0) break;
     if (root > max) root = max;
     if (max == 0) {                     /* no symbols to code at all */
-        here.op = (unsigned char)64;    /* invalid code marker */
-        here.bits = (unsigned char)1;
-        here.val = (unsigned short)0;
+        here.op = (unsigned char) 64;    /* invalid code marker */
+        here.bits = (unsigned char) 1;
+        here.val = (unsigned short) 0;
         *(*table)++ = here;             /* make a table to force an error */
         *(*table)++ = here;
         *bits = 1;
@@ -144,7 +142,7 @@ unsigned short FAR *work;
 
     /* sort symbols by length, by symbol order within each length */
     for (sym = 0; sym < codes; sym++)
-        if (lens[sym] != 0) work[offs[lens[sym]]++] = (unsigned short)sym;
+        if (lens[sym] != 0) work[offs[lens[sym]]++] = (unsigned short) sym;
 
     /*
        Create and fill in decoding tables.  In this loop, the table being
@@ -179,19 +177,19 @@ unsigned short FAR *work;
 
     /* set up for code type */
     switch (type) {
-    case CODES:
-        base = extra = work;    /* dummy value--not used */
-        match = 20;
-        break;
-    case LENS:
-        base = lbase;
-        extra = lext;
-        match = 257;
-        break;
-    default:    /* DISTS */
-        base = dbase;
-        extra = dext;
-        match = 0;
+        case CODES:
+            base = extra = work;    /* dummy value--not used */
+            match = 20;
+            break;
+        case LENS:
+            base = lbase;
+            extra = lext;
+            match = 257;
+            break;
+        default:    /* DISTS */
+            base = dbase;
+            extra = dext;
+            match = 0;
     }
 
     /* initialize state for loop */
@@ -201,7 +199,7 @@ unsigned short FAR *work;
     next = *table;              /* current table to fill in */
     curr = root;                /* current table index bits */
     drop = 0;                   /* current bits to drop from code for index */
-    low = (unsigned)(-1);       /* trigger new sub-table when len > root */
+    low = (unsigned) (-1);       /* trigger new sub-table when len > root */
     used = 1U << root;          /* use root table entries */
     mask = used - 1;            /* mask for comparing low */
 
@@ -213,17 +211,15 @@ unsigned short FAR *work;
     /* process all codes and make table entries */
     for (;;) {
         /* create table entry */
-        here.bits = (unsigned char)(len - drop);
+        here.bits = (unsigned char) (len - drop);
         if (work[sym] + 1U < match) {
-            here.op = (unsigned char)0;
+            here.op = (unsigned char) 0;
             here.val = work[sym];
-        }
-        else if (work[sym] >= match) {
-            here.op = (unsigned char)(extra[work[sym] - match]);
+        } else if (work[sym] >= match) {
+            here.op = (unsigned char) (extra[work[sym] - match]);
             here.val = base[work[sym] - match];
-        }
-        else {
-            here.op = (unsigned char)(32 + 64);         /* end of block */
+        } else {
+            here.op = (unsigned char) (32 + 64);         /* end of block */
             here.val = 0;
         }
 
@@ -243,8 +239,7 @@ unsigned short FAR *work;
         if (incr != 0) {
             huff &= incr - 1;
             huff += incr;
-        }
-        else
+        } else
             huff = 0;
 
         /* go to next symbol, update count, len */
@@ -265,7 +260,7 @@ unsigned short FAR *work;
 
             /* determine length of next table */
             curr = len - drop;
-            left = (int)(1 << curr);
+            left = (int) (1 << curr);
             while (curr + drop < max) {
                 left -= count[curr + drop];
                 if (left <= 0) break;
@@ -281,9 +276,9 @@ unsigned short FAR *work;
 
             /* point entry in root table to sub-table */
             low = huff & mask;
-            (*table)[low].op = (unsigned char)curr;
-            (*table)[low].bits = (unsigned char)root;
-            (*table)[low].val = (unsigned short)(next - *table);
+            (*table)[low].op = (unsigned char) curr;
+            (*table)[low].bits = (unsigned char) root;
+            (*table)[low].val = (unsigned short) (next - *table);
         }
     }
 
@@ -291,9 +286,9 @@ unsigned short FAR *work;
        at most one remaining entry, since if the code is incomplete, the
        maximum code length that was allowed to get this far is one bit) */
     if (huff != 0) {
-        here.op = (unsigned char)64;            /* invalid code marker */
-        here.bits = (unsigned char)(len - drop);
-        here.val = (unsigned short)0;
+        here.op = (unsigned char) 64;            /* invalid code marker */
+        here.bits = (unsigned char) (len - drop);
+        here.val = (unsigned short) 0;
         next[huff] = here;
     }
 

--- a/external/zlib/minigzip.c
+++ b/external/zlib/minigzip.c
@@ -55,7 +55,7 @@
 
 #if !defined(Z_HAVE_UNISTD_H) && !defined(_LARGEFILE64_SOURCE)
 #ifndef WIN32 /* unlink already in stdio.h for WIN32 */
-  extern int unlink OF((const char *));
+extern int unlink OF((const char *));
 #endif
 #endif
 
@@ -133,29 +133,33 @@ static void pwinerror (s)
 
 #ifdef MAXSEG_64K
 #  define local static
-   /* Needed for systems with limitation on stack size. */
+/* Needed for systems with limitation on stack size. */
 #else
 #  define local
 #endif
 
 char *prog;
 
-void error            OF((const char *msg));
-void gz_compress      OF((FILE   *in, gzFile out));
+void error OF((const char *msg));
+
+void gz_compress OF((FILE * in, gzFile out));
+
 #ifdef USE_MMAP
 int  gz_compress_mmap OF((FILE   *in, gzFile out));
 #endif
-void gz_uncompress    OF((gzFile in, FILE   *out));
-void file_compress    OF((char  *file, char *mode));
-void file_uncompress  OF((char  *file));
-int  main             OF((int argc, char *argv[]));
+
+void gz_uncompress OF((gzFile in, FILE * out));
+
+void file_compress OF((char  *file, char *mode));
+
+void file_uncompress OF((char  *file));
+
+int main OF((int argc, char *argv[]));
 
 /* ===========================================================================
  * Display error message and exit
  */
-void error(msg)
-    const char *msg;
-{
+void error(const char *msg) {
     fprintf(stderr, "%s: %s\n", prog, msg);
     exit(1);
 }
@@ -164,10 +168,8 @@ void error(msg)
  * Compress input to output then close both files.
  */
 
-void gz_compress(in, out)
-    FILE   *in;
-    gzFile out;
-{
+void gz_compress(FILE *in,
+                 gzFile out0 {
     local char buf[BUFLEN];
     int len;
     int err;
@@ -179,14 +181,14 @@ void gz_compress(in, out)
     if (gz_compress_mmap(in, out) == Z_OK) return;
 #endif
     for (;;) {
-        len = (int)fread(buf, 1, sizeof(buf), in);
+        len = (int) fread(buf, 1, sizeof(buf), in);
         if (ferror(in)) {
             perror("fread");
             exit(1);
         }
         if (len == 0) break;
 
-        if (gzwrite(out, buf, (unsigned)len) != len) error(gzerror(out, &err));
+        if (gzwrite(out, buf, (unsigned) len) != len) error(gzerror(out, &err));
     }
     fclose(in);
     if (gzclose(out) != Z_OK) error("failed gzclose");
@@ -232,20 +234,18 @@ int gz_compress_mmap(in, out)
 /* ===========================================================================
  * Uncompress input to output then close both files.
  */
-void gz_uncompress(in, out)
-    gzFile in;
-    FILE   *out;
-{
+void gz_uncompress(gzFile in,
+                   FILE *out) {
     local char buf[BUFLEN];
     int len;
     int err;
 
     for (;;) {
         len = gzread(in, buf, sizeof(buf));
-        if (len < 0) error (gzerror(in, &err));
+        if (len < 0) error(gzerror(in, &err));
         if (len == 0) break;
 
-        if ((int)fwrite(buf, 1, (unsigned)len, out) != len) {
+        if ((int) fwrite(buf, 1, (unsigned) len, out) != len) {
             error("failed fwrite");
         }
     }
@@ -259,12 +259,10 @@ void gz_uncompress(in, out)
  * Compress the given file: create a corresponding .gz file and remove the
  * original.
  */
-void file_compress(file, mode)
-    char  *file;
-    char  *mode;
-{
+void file_compress(char *file,
+                   char *mode) {
     local char outfile[MAX_NAME_LEN];
-    FILE  *in;
+    FILE *in;
     gzFile out;
 
     if (strlen(file) + strlen(GZ_SUFFIX) >= sizeof(outfile)) {
@@ -294,12 +292,10 @@ void file_compress(file, mode)
 /* ===========================================================================
  * Uncompress the given file and remove the original.
  */
-void file_uncompress(file)
-    char  *file;
-{
+void file_uncompress(char *file) {
     local char buf[MAX_NAME_LEN];
     char *infile, *outfile;
-    FILE  *out;
+    FILE *out;
     gzFile in;
     size_t len = strlen(file);
 
@@ -310,10 +306,10 @@ void file_uncompress(file)
 
     strcpy(buf, file);
 
-    if (len > SUFFIX_LEN && strcmp(file+len-SUFFIX_LEN, GZ_SUFFIX) == 0) {
+    if (len > SUFFIX_LEN && strcmp(file + len - SUFFIX_LEN, GZ_SUFFIX) == 0) {
         infile = file;
         outfile = buf;
-        outfile[len-3] = '\0';
+        outfile[len - 3] = '\0';
     } else {
         outfile = file;
         infile = buf;
@@ -346,10 +342,7 @@ void file_uncompress(file)
  *   -1 to -9 : compression level
  */
 
-int main(argc, argv)
-    int argc;
-    char *argv[];
-{
+int main(int argc, char *argv[]) {
     int copyout = 0;
     int uncompr = 0;
     gzFile file;
@@ -360,33 +353,33 @@ int main(argc, argv)
     prog = argv[0];
     bname = strrchr(argv[0], '/');
     if (bname)
-      bname++;
+        bname++;
     else
-      bname = argv[0];
+        bname = argv[0];
     argc--, argv++;
 
     if (!strcmp(bname, "gunzip"))
-      uncompr = 1;
+        uncompr = 1;
     else if (!strcmp(bname, "zcat"))
-      copyout = uncompr = 1;
+        copyout = uncompr = 1;
 
     while (argc > 0) {
-      if (strcmp(*argv, "-c") == 0)
-        copyout = 1;
-      else if (strcmp(*argv, "-d") == 0)
-        uncompr = 1;
-      else if (strcmp(*argv, "-f") == 0)
-        outmode[3] = 'f';
-      else if (strcmp(*argv, "-h") == 0)
-        outmode[3] = 'h';
-      else if (strcmp(*argv, "-r") == 0)
-        outmode[3] = 'R';
-      else if ((*argv)[0] == '-' && (*argv)[1] >= '1' && (*argv)[1] <= '9' &&
-               (*argv)[2] == 0)
-        outmode[2] = (*argv)[1];
-      else
-        break;
-      argc--, argv++;
+        if (strcmp(*argv, "-c") == 0)
+            copyout = 1;
+        else if (strcmp(*argv, "-d") == 0)
+            uncompr = 1;
+        else if (strcmp(*argv, "-f") == 0)
+            outmode[3] = 'f';
+        else if (strcmp(*argv, "-h") == 0)
+            outmode[3] = 'h';
+        else if (strcmp(*argv, "-r") == 0)
+            outmode[3] = 'R';
+        else if ((*argv)[0] == '-' && (*argv)[1] >= '1' && (*argv)[1] <= '9' &&
+                 (*argv)[2] == 0)
+            outmode[2] = (*argv)[1];
+        else
+            break;
+        argc--, argv++;
     }
     if (outmode[3] == ' ')
         outmode[3] = 0;
@@ -419,7 +412,7 @@ int main(argc, argv)
                 }
             } else {
                 if (copyout) {
-                    FILE * in = fopen(*argv, "rb");
+                    FILE *in = fopen(*argv, "rb");
 
                     if (in == NULL) {
                         perror(*argv);

--- a/external/zlib/trees.c
+++ b/external/zlib/trees.c
@@ -60,16 +60,16 @@
 /* repeat a zero length 11-138 times  (7 bits of repeat count) */
 
 local const int extra_lbits[LENGTH_CODES] /* extra bits for each length code */
-   = {0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0};
+        = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0};
 
 local const int extra_dbits[D_CODES] /* extra bits for each distance code */
-   = {0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13};
+        = {0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13};
 
 local const int extra_blbits[BL_CODES]/* extra bits for each bit length code */
-   = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,3,7};
+        = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 7};
 
 local const uch bl_order[BL_CODES]
-   = {16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15};
+        = {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
 /* The lengths of the bit length codes are sent in order of decreasing
  * probability, to avoid transmitting the lengths for unused bit length codes.
  */
@@ -83,7 +83,7 @@ local const uch bl_order[BL_CODES]
 #if defined(GEN_TREES_H) || !defined(STDC)
 /* non ANSI compilers may not accept trees.h */
 
-local ct_data static_ltree[L_CODES+2];
+local ct_data static_ltree[L_CODES + 2];
 /* The static literal tree. Since the bit lengths are imposed, there is no
  * need for the L_CODES extra codes used during heap construction. However
  * The codes 286 and 287 are needed to build a canonical tree (see _tr_init
@@ -101,7 +101,7 @@ uch _dist_code[DIST_CODE_LEN];
  * the 15 bit distances.
  */
 
-uch _length_code[MAX_MATCH-MIN_MATCH+1];
+uch _length_code[MAX_MATCH - MIN_MATCH + 1];
 /* length code for each normalized match length (0 == MIN_MATCH) */
 
 local int base_length[LENGTH_CODES];
@@ -117,41 +117,55 @@ local int base_dist[D_CODES];
 struct static_tree_desc_s {
     const ct_data *static_tree;  /* static tree or NULL */
     const intf *extra_bits;      /* extra bits for each code or NULL */
-    int     extra_base;          /* base index for extra_bits */
-    int     elems;               /* max number of elements in the tree */
-    int     max_length;          /* max bit length for the codes */
+    int extra_base;          /* base index for extra_bits */
+    int elems;               /* max number of elements in the tree */
+    int max_length;          /* max bit length for the codes */
 };
 
-local const static_tree_desc  static_l_desc =
-{static_ltree, extra_lbits, LITERALS+1, L_CODES, MAX_BITS};
+local const static_tree_desc static_l_desc =
+        {static_ltree, extra_lbits, LITERALS + 1, L_CODES, MAX_BITS};
 
-local const static_tree_desc  static_d_desc =
-{static_dtree, extra_dbits, 0,          D_CODES, MAX_BITS};
+local const static_tree_desc static_d_desc =
+        {static_dtree, extra_dbits, 0, D_CODES, MAX_BITS};
 
-local const static_tree_desc  static_bl_desc =
-{(const ct_data *)0, extra_blbits, 0,   BL_CODES, MAX_BL_BITS};
+local const static_tree_desc static_bl_desc =
+        {(const ct_data *) 0, extra_blbits, 0, BL_CODES, MAX_BL_BITS};
 
 /* ===========================================================================
  * Local (static) routines in this file.
  */
 
 local void tr_static_init OF((void));
-local void init_block     OF((deflate_state *s));
-local void pqdownheap     OF((deflate_state *s, ct_data *tree, int k));
-local void gen_bitlen     OF((deflate_state *s, tree_desc *desc));
-local void gen_codes      OF((ct_data *tree, int max_code, ushf *bl_count));
-local void build_tree     OF((deflate_state *s, tree_desc *desc));
-local void scan_tree      OF((deflate_state *s, ct_data *tree, int max_code));
-local void send_tree      OF((deflate_state *s, ct_data *tree, int max_code));
-local int  build_bl_tree  OF((deflate_state *s));
-local void send_all_trees OF((deflate_state *s, int lcodes, int dcodes,
-                              int blcodes));
-local void compress_block OF((deflate_state *s, const ct_data *ltree,
-                              const ct_data *dtree));
-local int  detect_data_type OF((deflate_state *s));
+
+local void init_block OF((deflate_state * s));
+
+local void pqdownheap OF((deflate_state * s, ct_data * tree, int k));
+
+local void gen_bitlen OF((deflate_state * s, tree_desc * desc));
+
+local void gen_codes OF((ct_data * tree, int max_code, ushf *bl_count));
+
+local void build_tree OF((deflate_state * s, tree_desc * desc));
+
+local void scan_tree OF((deflate_state * s, ct_data * tree, int max_code));
+
+local void send_tree OF((deflate_state * s, ct_data * tree, int max_code));
+
+local int build_bl_tree OF((deflate_state * s));
+
+local void send_all_trees OF((deflate_state * s, int lcodes, int dcodes,
+                                     int blcodes));
+
+local void compress_block OF((deflate_state * s, const ct_data *ltree,
+                                     const ct_data *dtree));
+
+local int detect_data_type OF((deflate_state * s));
+
 local unsigned bi_reverse OF((unsigned code, int len));
-local void bi_windup      OF((deflate_state *s));
-local void bi_flush       OF((deflate_state *s));
+
+local void bi_windup OF((deflate_state * s));
+
+local void bi_flush OF((deflate_state * s));
 
 #ifdef GEN_TREES_H
 local void gen_trees_header OF((void));
@@ -159,7 +173,7 @@ local void gen_trees_header OF((void));
 
 #ifndef ZLIB_DEBUG
 #  define send_code(s, c, tree) send_bits(s, tree[c].Code, tree[c].Len)
-   /* Send a code of the given tree. c and tree must not have side effects */
+/* Send a code of the given tree. c and tree must not have side effects */
 
 #else /* !ZLIB_DEBUG */
 #  define send_code(s, c, tree) \
@@ -229,8 +243,7 @@ local void send_bits(s, value, length)
 /* ===========================================================================
  * Initialize the various 'constant' tables.
  */
-local void tr_static_init()
-{
+local void tr_static_init() {
 #if defined(GEN_TREES_H) || !defined(STDC)
     static int static_init_done = 0;
     int n;        /* iterates over tree elements */
@@ -238,7 +251,7 @@ local void tr_static_init()
     int length;   /* length value */
     int code;     /* code value */
     int dist;     /* distance index */
-    ush bl_count[MAX_BITS+1];
+    ush bl_count[MAX_BITS + 1];
     /* number of codes at each bit length for an optimal tree */
 
     if (static_init_done) return;
@@ -254,10 +267,10 @@ local void tr_static_init()
 
     /* Initialize the mapping length (0..255) -> length code (0..28) */
     length = 0;
-    for (code = 0; code < LENGTH_CODES-1; code++) {
+    for (code = 0; code < LENGTH_CODES - 1; code++) {
         base_length[code] = length;
         for (n = 0; n < (1 << extra_lbits[code]); n++) {
-            _length_code[length++] = (uch)code;
+            _length_code[length++] = (uch) code;
         }
     }
     Assert (length == 256, "tr_static_init: length != 256");
@@ -265,22 +278,22 @@ local void tr_static_init()
      * in two different ways: code 284 + 5 bits or code 285, so we
      * overwrite length_code[255] to use the best encoding:
      */
-    _length_code[length - 1] = (uch)code;
+    _length_code[length - 1] = (uch) code;
 
     /* Initialize the mapping dist (0..32K) -> dist code (0..29) */
     dist = 0;
-    for (code = 0 ; code < 16; code++) {
+    for (code = 0; code < 16; code++) {
         base_dist[code] = dist;
         for (n = 0; n < (1 << extra_dbits[code]); n++) {
-            _dist_code[dist++] = (uch)code;
+            _dist_code[dist++] = (uch) code;
         }
     }
     Assert (dist == 256, "tr_static_init: dist != 256");
     dist >>= 7; /* from now on, all distances are divided by 128 */
-    for ( ; code < D_CODES; code++) {
+    for (; code < D_CODES; code++) {
         base_dist[code] = dist << 7;
         for (n = 0; n < (1 << (extra_dbits[code] - 7)); n++) {
-            _dist_code[256 + dist++] = (uch)code;
+            _dist_code[256 + dist++] = (uch) code;
         }
     }
     Assert (dist == 256, "tr_static_init: 256 + dist != 512");
@@ -296,12 +309,12 @@ local void tr_static_init()
      * tree construction to get a canonical Huffman tree (longest code
      * all ones)
      */
-    gen_codes((ct_data *)static_ltree, L_CODES+1, bl_count);
+    gen_codes((ct_data *) static_ltree, L_CODES + 1, bl_count);
 
     /* The static distance tree is trivial: */
     for (n = 0; n < D_CODES; n++) {
         static_dtree[n].Len = 5;
-        static_dtree[n].Code = bi_reverse((unsigned)n, 5);
+        static_dtree[n].Code = bi_reverse((unsigned) n, 5);
     }
     static_init_done = 1;
 
@@ -376,9 +389,7 @@ void gen_trees_header()
 /* ===========================================================================
  * Initialize the tree data structures for a new zlib stream.
  */
-void ZLIB_INTERNAL _tr_init(s)
-    deflate_state *s;
-{
+void ZLIB_INTERNAL _tr_init(deflate_state *s) {
     tr_static_init();
 
     s->l_desc.dyn_tree = s->dyn_ltree;
@@ -404,14 +415,12 @@ void ZLIB_INTERNAL _tr_init(s)
 /* ===========================================================================
  * Initialize a new block.
  */
-local void init_block(s)
-    deflate_state *s;
-{
+local void init_block(deflate_state *s) {
     int n; /* iterates over tree elements */
 
     /* Initialize the trees. */
-    for (n = 0; n < L_CODES;  n++) s->dyn_ltree[n].Freq = 0;
-    for (n = 0; n < D_CODES;  n++) s->dyn_dtree[n].Freq = 0;
+    for (n = 0; n < L_CODES; n++) s->dyn_ltree[n].Freq = 0;
+    for (n = 0; n < D_CODES; n++) s->dyn_dtree[n].Freq = 0;
     for (n = 0; n < BL_CODES; n++) s->bl_tree[n].Freq = 0;
 
     s->dyn_ltree[END_BLOCK].Freq = 1;
@@ -448,11 +457,9 @@ local void init_block(s)
  * when the heap property is re-established (each father smaller than its
  * two sons).
  */
-local void pqdownheap(s, tree, k)
-    deflate_state *s;
-    ct_data *tree;  /* the tree to restore */
-    int k;               /* node to move down */
-{
+local void pqdownheap(deflate_state *s,
+                      ct_data *tree,  /* the tree to restore */
+                      int k) {             /* node to move down */
     int v = s->heap[k];
     int j = k << 1;  /* left son of k */
     while (j <= s->heap_len) {
@@ -465,7 +472,8 @@ local void pqdownheap(s, tree, k)
         if (smaller(tree, v, s->heap[j], s->depth)) break;
 
         /* Exchange v with the smallest son */
-        s->heap[k] = s->heap[j];  k = j;
+        s->heap[k] = s->heap[j];
+        k = j;
 
         /* And continue down the tree, setting j to the left son of k */
         j <<= 1;
@@ -483,16 +491,14 @@ local void pqdownheap(s, tree, k)
  *     The length opt_len is updated; static_len is also updated if stree is
  *     not null.
  */
-local void gen_bitlen(s, desc)
-    deflate_state *s;
-    tree_desc *desc;    /* the tree descriptor */
-{
-    ct_data *tree        = desc->dyn_tree;
-    int max_code         = desc->max_code;
+local void gen_bitlen(deflate_state *s,
+                      tree_desc *desc) {    /* the tree descriptor */
+    ct_data *tree = desc->dyn_tree;
+    int max_code = desc->max_code;
     const ct_data *stree = desc->stat_desc->static_tree;
-    const intf *extra    = desc->stat_desc->extra_bits;
-    int base             = desc->stat_desc->extra_base;
-    int max_length       = desc->stat_desc->max_length;
+    const intf *extra = desc->stat_desc->extra_bits;
+    int base = desc->stat_desc->extra_base;
+    int max_length = desc->stat_desc->max_length;
     int h;              /* heap index */
     int n, m;           /* iterate over the tree elements */
     int bits;           /* bit length */
@@ -511,7 +517,7 @@ local void gen_bitlen(s, desc)
         n = s->heap[h];
         bits = tree[tree[n].Dad].Len + 1;
         if (bits > max_length) bits = max_length, overflow++;
-        tree[n].Len = (ush)bits;
+        tree[n].Len = (ush) bits;
         /* We overwrite tree[n].Dad which is no longer needed */
 
         if (n > max_code) continue; /* not a leaf node */
@@ -520,12 +526,12 @@ local void gen_bitlen(s, desc)
         xbits = 0;
         if (n >= base) xbits = extra[n - base];
         f = tree[n].Freq;
-        s->opt_len += (ulg)f * (unsigned)(bits + xbits);
-        if (stree) s->static_len += (ulg)f * (unsigned)(stree[n].Len + xbits);
+        s->opt_len += (ulg) f * (unsigned) (bits + xbits);
+        if (stree) s->static_len += (ulg) f * (unsigned) (stree[n].Len + xbits);
     }
     if (overflow == 0) return;
 
-    Tracev((stderr,"\nbit length overflow\n"));
+    Tracev((stderr, "\nbit length overflow\n"));
     /* This happens for example on obj2 and pic of the Calgary corpus */
 
     /* Find the first bit length which could increase: */
@@ -552,9 +558,9 @@ local void gen_bitlen(s, desc)
             m = s->heap[--h];
             if (m > max_code) continue;
             if ((unsigned) tree[m].Len != (unsigned) bits) {
-                Tracev((stderr,"code %d bits %d->%d\n", m, tree[m].Len, bits));
-                s->opt_len += ((ulg)bits - tree[m].Len) * tree[m].Freq;
-                tree[m].Len = (ush)bits;
+                Tracev((stderr, "code %d bits %d->%d\n", m, tree[m].Len, bits));
+                s->opt_len += ((ulg) bits - tree[m].Len) * tree[m].Freq;
+                tree[m].Len = (ush) bits;
             }
             n--;
         }
@@ -569,12 +575,10 @@ local void gen_bitlen(s, desc)
  * OUT assertion: the field code is set for all tree elements of non
  *     zero code length.
  */
-local void gen_codes(tree, max_code, bl_count)
-    ct_data *tree;             /* the tree to decorate */
-    int max_code;              /* largest code with non zero frequency */
-    ushf *bl_count;            /* number of codes at each bit length */
-{
-    ush next_code[MAX_BITS+1]; /* next code value for each bit length */
+local void gen_codes(ct_data *tree,             /* the tree to decorate */
+                     int max_code,              /* largest code with non zero frequency */
+                     ushf *bl_count) {            /* number of codes at each bit length */
+    ush next_code[MAX_BITS + 1]; /* next code value for each bit length */
     unsigned code = 0;         /* running code value */
     int bits;                  /* bit index */
     int n;                     /* code index */
@@ -584,23 +588,23 @@ local void gen_codes(tree, max_code, bl_count)
      */
     for (bits = 1; bits <= MAX_BITS; bits++) {
         code = (code + bl_count[bits - 1]) << 1;
-        next_code[bits] = (ush)code;
+        next_code[bits] = (ush) code;
     }
     /* Check that the bit counts in bl_count are consistent. The last code
      * must be all ones.
      */
     Assert (code + bl_count[MAX_BITS] - 1 == (1 << MAX_BITS) - 1,
             "inconsistent bit counts");
-    Tracev((stderr,"\ngen_codes: max_code %d ", max_code));
+    Tracev((stderr, "\ngen_codes: max_code %d ", max_code));
 
-    for (n = 0;  n <= max_code; n++) {
+    for (n = 0; n <= max_code; n++) {
         int len = tree[n].Len;
         if (len == 0) continue;
         /* Now reverse the bits */
-        tree[n].Code = (ush)bi_reverse(next_code[len]++, len);
+        tree[n].Code = (ush) bi_reverse(next_code[len]++, len);
 
-        Tracecv(tree != static_ltree, (stderr,"\nn %3d %c l %2d c %4x (%x) ",
-            n, (isgraph(n) ? n : ' '), len, tree[n].Code, next_code[len] - 1));
+        Tracecv(tree != static_ltree, (stderr, "\nn %3d %c l %2d c %4x (%x) ",
+                n, (isgraph(n) ? n : ' '), len, tree[n].Code, next_code[len] - 1));
     }
 }
 
@@ -612,13 +616,11 @@ local void gen_codes(tree, max_code, bl_count)
  *     and corresponding code. The length opt_len is updated; static_len is
  *     also updated if stree is not null. The field max_code is set.
  */
-local void build_tree(s, desc)
-    deflate_state *s;
-    tree_desc *desc; /* the tree descriptor */
-{
-    ct_data *tree         = desc->dyn_tree;
-    const ct_data *stree  = desc->stat_desc->static_tree;
-    int elems             = desc->stat_desc->elems;
+local void build_tree(deflate_state *s,
+                      tree_desc *desc) { /* the tree descriptor */
+    ct_data *tree = desc->dyn_tree;
+    const ct_data *stree = desc->stat_desc->static_tree;
+    int elems = desc->stat_desc->elems;
     int n, m;          /* iterate over heap elements */
     int max_code = -1; /* largest code with non zero frequency */
     int node;          /* new node being created */
@@ -647,7 +649,8 @@ local void build_tree(s, desc)
         node = s->heap[++(s->heap_len)] = (max_code < 2 ? ++max_code : 0);
         tree[node].Freq = 1;
         s->depth[node] = 0;
-        s->opt_len--; if (stree) s->static_len -= stree[node].Len;
+        s->opt_len--;
+        if (stree) s->static_len -= stree[node].Len;
         /* node is 0 or 1 so it does not have extra bits */
     }
     desc->max_code = max_code;
@@ -655,7 +658,7 @@ local void build_tree(s, desc)
     /* The elements heap[heap_len/2 + 1 .. heap_len] are leaves of the tree,
      * establish sub-heaps of increasing lengths:
      */
-    for (n = s->heap_len/2; n >= 1; n--) pqdownheap(s, tree, n);
+    for (n = s->heap_len / 2; n >= 1; n--) pqdownheap(s, tree, n);
 
     /* Construct the Huffman tree by repeatedly combining the least two
      * frequent nodes.
@@ -670,9 +673,9 @@ local void build_tree(s, desc)
 
         /* Create a new node father of n and m */
         tree[node].Freq = tree[n].Freq + tree[m].Freq;
-        s->depth[node] = (uch)((s->depth[n] >= s->depth[m] ?
-                                s->depth[n] : s->depth[m]) + 1);
-        tree[n].Dad = tree[m].Dad = (ush)node;
+        s->depth[node] = (uch) ((s->depth[n] >= s->depth[m] ?
+                                 s->depth[n] : s->depth[m]) + 1);
+        tree[n].Dad = tree[m].Dad = (ush) node;
 #ifdef DUMP_BL_TREE
         if (tree == s->bl_tree) {
             fprintf(stderr,"\nnode %d(%d), sons %d(%d) %d(%d)",
@@ -690,21 +693,19 @@ local void build_tree(s, desc)
     /* At this point, the fields freq and dad are set. We can now
      * generate the bit lengths.
      */
-    gen_bitlen(s, (tree_desc *)desc);
+    gen_bitlen(s, (tree_desc *) desc);
 
     /* The field len is now set, we can generate the bit codes */
-    gen_codes ((ct_data *)tree, max_code, s->bl_count);
+    gen_codes((ct_data *) tree, max_code, s->bl_count);
 }
 
 /* ===========================================================================
  * Scan a literal or distance tree to determine the frequencies of the codes
  * in the bit length tree.
  */
-local void scan_tree(s, tree, max_code)
-    deflate_state *s;
-    ct_data *tree;   /* the tree to be scanned */
-    int max_code;    /* and its largest code of non zero frequency */
-{
+local void scan_tree(deflate_state *s,
+                     ct_data *tree,   /* the tree to be scanned */
+                     int max_code) {    /* and its largest code of non zero frequency */
     int n;                     /* iterates over all tree elements */
     int prevlen = -1;          /* last emitted length */
     int curlen;                /* length of current code */
@@ -714,10 +715,11 @@ local void scan_tree(s, tree, max_code)
     int min_count = 4;         /* min repeat count */
 
     if (nextlen == 0) max_count = 138, min_count = 3;
-    tree[max_code + 1].Len = (ush)0xffff; /* guard */
+    tree[max_code + 1].Len = (ush) 0xffff; /* guard */
 
     for (n = 0; n <= max_code; n++) {
-        curlen = nextlen; nextlen = tree[n + 1].Len;
+        curlen = nextlen;
+        nextlen = tree[n + 1].Len;
         if (++count < max_count && curlen == nextlen) {
             continue;
         } else if (count < min_count) {
@@ -730,7 +732,8 @@ local void scan_tree(s, tree, max_code)
         } else {
             s->bl_tree[REPZ_11_138].Freq++;
         }
-        count = 0; prevlen = curlen;
+        count = 0;
+        prevlen = curlen;
         if (nextlen == 0) {
             max_count = 138, min_count = 3;
         } else if (curlen == nextlen) {
@@ -745,11 +748,9 @@ local void scan_tree(s, tree, max_code)
  * Send a literal or distance tree in compressed form, using the codes in
  * bl_tree.
  */
-local void send_tree(s, tree, max_code)
-    deflate_state *s;
-    ct_data *tree; /* the tree to be scanned */
-    int max_code;       /* and its largest code of non zero frequency */
-{
+local void send_tree(deflate_state *s,
+                     ct_data *tree, /* the tree to be scanned */
+                     int max_code) {      /* and its largest code of non zero frequency */
     int n;                     /* iterates over all tree elements */
     int prevlen = -1;          /* last emitted length */
     int curlen;                /* length of current code */
@@ -762,26 +763,32 @@ local void send_tree(s, tree, max_code)
     if (nextlen == 0) max_count = 138, min_count = 3;
 
     for (n = 0; n <= max_code; n++) {
-        curlen = nextlen; nextlen = tree[n + 1].Len;
+        curlen = nextlen;
+        nextlen = tree[n + 1].Len;
         if (++count < max_count && curlen == nextlen) {
             continue;
         } else if (count < min_count) {
-            do { send_code(s, curlen, s->bl_tree); } while (--count != 0);
+            do {send_code(s, curlen, s->bl_tree); } while (--count != 0);
 
         } else if (curlen != 0) {
             if (curlen != prevlen) {
-                send_code(s, curlen, s->bl_tree); count--;
+                send_code(s, curlen, s->bl_tree);
+                count--;
             }
             Assert(count >= 3 && count <= 6, " 3_6?");
-            send_code(s, REP_3_6, s->bl_tree); send_bits(s, count - 3, 2);
+            send_code(s, REP_3_6, s->bl_tree);
+            send_bits(s, count - 3, 2);
 
         } else if (count <= 10) {
-            send_code(s, REPZ_3_10, s->bl_tree); send_bits(s, count - 3, 3);
+            send_code(s, REPZ_3_10, s->bl_tree);
+            send_bits(s, count - 3, 3);
 
         } else {
-            send_code(s, REPZ_11_138, s->bl_tree); send_bits(s, count - 11, 7);
+            send_code(s, REPZ_11_138, s->bl_tree);
+            send_bits(s, count - 11, 7);
         }
-        count = 0; prevlen = curlen;
+        count = 0;
+        prevlen = curlen;
         if (nextlen == 0) {
             max_count = 138, min_count = 3;
         } else if (curlen == nextlen) {
@@ -796,17 +803,15 @@ local void send_tree(s, tree, max_code)
  * Construct the Huffman tree for the bit lengths and return the index in
  * bl_order of the last bit length code to send.
  */
-local int build_bl_tree(s)
-    deflate_state *s;
-{
+local int build_bl_tree(deflate_state *s) {
     int max_blindex;  /* index of last bit length code of non zero freq */
 
     /* Determine the bit length frequencies for literal and distance trees */
-    scan_tree(s, (ct_data *)s->dyn_ltree, s->l_desc.max_code);
-    scan_tree(s, (ct_data *)s->dyn_dtree, s->d_desc.max_code);
+    scan_tree(s, (ct_data *) s->dyn_ltree, s->l_desc.max_code);
+    scan_tree(s, (ct_data *) s->dyn_dtree, s->d_desc.max_code);
 
     /* Build the bit length tree: */
-    build_tree(s, (tree_desc *)(&(s->bl_desc)));
+    build_tree(s, (tree_desc *) (&(s->bl_desc)));
     /* opt_len now includes the length of the tree representations, except the
      * lengths of the bit lengths codes and the 5 + 5 + 4 bits for the counts.
      */
@@ -815,11 +820,11 @@ local int build_bl_tree(s)
      * requires that at least 4 bit length codes be sent. (appnote.txt says
      * 3 but the actual value used is 4.)
      */
-    for (max_blindex = BL_CODES-1; max_blindex >= 3; max_blindex--) {
+    for (max_blindex = BL_CODES - 1; max_blindex >= 3; max_blindex--) {
         if (s->bl_tree[bl_order[max_blindex]].Len != 0) break;
     }
     /* Update opt_len to include the bit length tree and counts */
-    s->opt_len += 3*((ulg)max_blindex + 1) + 5 + 5 + 4;
+    s->opt_len += 3 * ((ulg) max_blindex + 1) + 5 + 5 + 4;
     Tracev((stderr, "\ndyn trees: dyn %ld, stat %ld",
             s->opt_len, s->static_len));
 
@@ -831,10 +836,10 @@ local int build_bl_tree(s)
  * lengths of the bit length codes, the literal tree and the distance tree.
  * IN assertion: lcodes >= 257, dcodes >= 1, blcodes >= 4.
  */
-local void send_all_trees(s, lcodes, dcodes, blcodes)
-    deflate_state *s;
-    int lcodes, dcodes, blcodes; /* number of codes for each tree */
-{
+local void send_all_trees(deflate_state *s,
+                          int lcodes,
+                          int dcodes,
+                          int blcodes) { /* number of codes for each tree */
     int rank;                    /* index in bl_order */
 
     Assert (lcodes >= 257 && dcodes >= 1 && blcodes >= 4, "not enough codes");
@@ -842,36 +847,34 @@ local void send_all_trees(s, lcodes, dcodes, blcodes)
             "too many codes");
     Tracev((stderr, "\nbl counts: "));
     send_bits(s, lcodes - 257, 5);  /* not +255 as stated in appnote.txt */
-    send_bits(s, dcodes - 1,   5);
-    send_bits(s, blcodes - 4,  4);  /* not -3 as stated in appnote.txt */
+    send_bits(s, dcodes - 1, 5);
+    send_bits(s, blcodes - 4, 4);  /* not -3 as stated in appnote.txt */
     for (rank = 0; rank < blcodes; rank++) {
         Tracev((stderr, "\nbl code %2d ", bl_order[rank]));
         send_bits(s, s->bl_tree[bl_order[rank]].Len, 3);
     }
     Tracev((stderr, "\nbl tree: sent %ld", s->bits_sent));
 
-    send_tree(s, (ct_data *)s->dyn_ltree, lcodes - 1);  /* literal tree */
+    send_tree(s, (ct_data *) s->dyn_ltree, lcodes - 1);  /* literal tree */
     Tracev((stderr, "\nlit tree: sent %ld", s->bits_sent));
 
-    send_tree(s, (ct_data *)s->dyn_dtree, dcodes - 1);  /* distance tree */
+    send_tree(s, (ct_data *) s->dyn_dtree, dcodes - 1);  /* distance tree */
     Tracev((stderr, "\ndist tree: sent %ld", s->bits_sent));
 }
 
 /* ===========================================================================
  * Send a stored block
  */
-void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
-    deflate_state *s;
-    charf *buf;       /* input block */
-    ulg stored_len;   /* length of input block */
-    int last;         /* one if this is the last block for a file */
-{
-    send_bits(s, (STORED_BLOCK<<1) + last, 3);  /* send block type */
+void ZLIB_INTERNAL _tr_stored_block(deflate_state *s,
+                                    charf *buf,       /* input block */
+                                    ulg stored_len,   /* length of input block */
+                                    int last) {        /* one if this is the last block for a file */
+    send_bits(s, (STORED_BLOCK << 1) + last, 3);  /* send block type */
     bi_windup(s);        /* align on byte boundary */
-    put_short(s, (ush)stored_len);
-    put_short(s, (ush)~stored_len);
+    put_short(s, (ush) stored_len);
+    put_short(s, (ush) ~stored_len);
     if (stored_len)
-        zmemcpy(s->pending_buf + s->pending, (Bytef *)buf, stored_len);
+        zmemcpy(s->pending_buf + s->pending, (Bytef *) buf, stored_len);
     s->pending += stored_len;
 #ifdef ZLIB_DEBUG
     s->compressed_len = (s->compressed_len + 3 + 7) & (ulg)~7L;
@@ -884,9 +887,7 @@ void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
 /* ===========================================================================
  * Flush the bits in the bit buffer to pending output (leaves at most 7 bits)
  */
-void ZLIB_INTERNAL _tr_flush_bits(s)
-    deflate_state *s;
-{
+void ZLIB_INTERNAL _tr_flush_bits(deflate_state *s) {
     bi_flush(s);
 }
 
@@ -894,10 +895,8 @@ void ZLIB_INTERNAL _tr_flush_bits(s)
  * Send one empty static block to give enough lookahead for inflate.
  * This takes 10 bits, of which 7 may remain in the bit buffer.
  */
-void ZLIB_INTERNAL _tr_align(s)
-    deflate_state *s;
-{
-    send_bits(s, STATIC_TREES<<1, 3);
+void ZLIB_INTERNAL _tr_align(deflate_state *s) {
+    send_bits(s, STATIC_TREES << 1, 3);
     send_code(s, END_BLOCK, static_ltree);
 #ifdef ZLIB_DEBUG
     s->compressed_len += 10L; /* 3 for block type, 7 for EOB */
@@ -909,12 +908,10 @@ void ZLIB_INTERNAL _tr_align(s)
  * Determine the best encoding for the current block: dynamic trees, static
  * trees or store, and write out the encoded block.
  */
-void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
-    deflate_state *s;
-    charf *buf;       /* input block, or NULL if too old */
-    ulg stored_len;   /* length of input block */
-    int last;         /* one if this is the last block for a file */
-{
+void ZLIB_INTERNAL _tr_flush_block(deflate_state *s,
+                                   charf *buf,       /* input block, or NULL if too old */
+                                   ulg stored_len,   /* length of input block */
+                                   int last) {         /* one if this is the last block for a file */
     ulg opt_lenb, static_lenb; /* opt_len and static_len in bytes */
     int max_blindex = 0;  /* index of last bit length code of non zero freq */
 
@@ -926,11 +923,11 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
             s->strm->data_type = detect_data_type(s);
 
         /* Construct the literal and distance trees */
-        build_tree(s, (tree_desc *)(&(s->l_desc)));
+        build_tree(s, (tree_desc *) (&(s->l_desc)));
         Tracev((stderr, "\nlit data: dyn %ld, stat %ld", s->opt_len,
                 s->static_len));
 
-        build_tree(s, (tree_desc *)(&(s->d_desc)));
+        build_tree(s, (tree_desc *) (&(s->d_desc)));
         Tracev((stderr, "\ndist data: dyn %ld, stat %ld", s->opt_len,
                 s->static_len));
         /* At this point, opt_len and static_len are the total bit lengths of
@@ -956,15 +953,15 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
             opt_lenb = static_lenb;
 
     } else {
-        Assert(buf != (char*)0, "lost buf");
+        Assert(buf != (char *) 0, "lost buf");
         opt_lenb = static_lenb = stored_len + 5; /* force a stored block */
     }
 
 #ifdef FORCE_STORED
     if (buf != (char*)0) { /* force stored block */
 #else
-    if (stored_len + 4 <= opt_lenb && buf != (char*)0) {
-                       /* 4: two words for the lengths */
+    if (stored_len + 4 <= opt_lenb && buf != (char *) 0) {
+        /* 4: two words for the lengths */
 #endif
         /* The test buf != NULL is only necessary if LIT_BUFSIZE > WSIZE.
          * Otherwise we can't have processed more than WSIZE input bytes since
@@ -975,18 +972,18 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
         _tr_stored_block(s, buf, stored_len, last);
 
     } else if (static_lenb == opt_lenb) {
-        send_bits(s, (STATIC_TREES<<1) + last, 3);
-        compress_block(s, (const ct_data *)static_ltree,
-                       (const ct_data *)static_dtree);
+        send_bits(s, (STATIC_TREES << 1) + last, 3);
+        compress_block(s, (const ct_data *) static_ltree,
+                       (const ct_data *) static_dtree);
 #ifdef ZLIB_DEBUG
         s->compressed_len += 3 + s->static_len;
 #endif
     } else {
-        send_bits(s, (DYN_TREES<<1) + last, 3);
+        send_bits(s, (DYN_TREES << 1) + last, 3);
         send_all_trees(s, s->l_desc.max_code + 1, s->d_desc.max_code + 1,
                        max_blindex + 1);
-        compress_block(s, (const ct_data *)s->dyn_ltree,
-                       (const ct_data *)s->dyn_dtree);
+        compress_block(s, (const ct_data *) s->dyn_ltree,
+                       (const ct_data *) s->dyn_dtree);
 #ifdef ZLIB_DEBUG
         s->compressed_len += 3 + s->opt_len;
 #endif
@@ -1003,22 +1000,20 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
         s->compressed_len += 7;  /* align on byte boundary */
 #endif
     }
-    Tracev((stderr,"\ncomprlen %lu(%lu) ", s->compressed_len >> 3,
-           s->compressed_len - 7*last));
+    Tracev((stderr, "\ncomprlen %lu(%lu) ", s->compressed_len >> 3,
+            s->compressed_len - 7 * last));
 }
 
 /* ===========================================================================
  * Save the match info and tally the frequency counts. Return true if
  * the current block must be flushed.
  */
-int ZLIB_INTERNAL _tr_tally(s, dist, lc)
-    deflate_state *s;
-    unsigned dist;  /* distance of matched string */
-    unsigned lc;    /* match length - MIN_MATCH or unmatched char (dist==0) */
-{
-    s->sym_buf[s->sym_next++] = (uch)dist;
-    s->sym_buf[s->sym_next++] = (uch)(dist >> 8);
-    s->sym_buf[s->sym_next++] = (uch)lc;
+int ZLIB_INTERNAL _tr_tally(deflate_state *s,
+                            unsigned dist,  /* distance of matched string */
+                            unsigned lc) {    /* match length - MIN_MATCH or unmatched char (dist==0) */
+    s->sym_buf[s->sym_next++] = (uch) dist;
+    s->sym_buf[s->sym_next++] = (uch) (dist >> 8);
+    s->sym_buf[s->sym_next++] = (uch) lc;
     if (dist == 0) {
         /* lc is the unmatched char */
         s->dyn_ltree[lc].Freq++;
@@ -1026,9 +1021,9 @@ int ZLIB_INTERNAL _tr_tally(s, dist, lc)
         s->matches++;
         /* Here, lc is the match length - MIN_MATCH */
         dist--;             /* dist = match distance - 1 */
-        Assert((ush)dist < (ush)MAX_DIST(s) &&
-               (ush)lc <= (ush)(MAX_MATCH-MIN_MATCH) &&
-               (ush)d_code(dist) < (ush)D_CODES,  "_tr_tally: bad match");
+        Assert((ush) dist < (ush) MAX_DIST(s) &&
+               (ush) lc <= (ush) (MAX_MATCH - MIN_MATCH) &&
+               (ush) d_code(dist) < (ush) D_CODES, "_tr_tally: bad match");
 
         s->dyn_ltree[_length_code[lc] + LITERALS + 1].Freq++;
         s->dyn_dtree[d_code(dist)].Freq++;
@@ -1039,49 +1034,48 @@ int ZLIB_INTERNAL _tr_tally(s, dist, lc)
 /* ===========================================================================
  * Send the block data compressed using the given Huffman trees
  */
-local void compress_block(s, ltree, dtree)
-    deflate_state *s;
-    const ct_data *ltree; /* literal tree */
-    const ct_data *dtree; /* distance tree */
-{
+local void compress_block(deflate_state *s,
+                          const ct_data *ltree, /* literal tree */
+                          const ct_data *dtree) { /* distance tree */
     unsigned dist;      /* distance of matched string */
     int lc;             /* match length or unmatched char (if dist == 0) */
     unsigned sx = 0;    /* running index in sym_buf */
     unsigned code;      /* the code to send */
     int extra;          /* number of extra bits to send */
 
-    if (s->sym_next != 0) do {
-        dist = s->sym_buf[sx++] & 0xff;
-        dist += (unsigned)(s->sym_buf[sx++] & 0xff) << 8;
-        lc = s->sym_buf[sx++];
-        if (dist == 0) {
-            send_code(s, lc, ltree); /* send a literal byte */
-            Tracecv(isgraph(lc), (stderr," '%c' ", lc));
-        } else {
-            /* Here, lc is the match length - MIN_MATCH */
-            code = _length_code[lc];
-            send_code(s, code + LITERALS + 1, ltree);   /* send length code */
-            extra = extra_lbits[code];
-            if (extra != 0) {
-                lc -= base_length[code];
-                send_bits(s, lc, extra);       /* send the extra length bits */
-            }
-            dist--; /* dist is now the match distance - 1 */
-            code = d_code(dist);
-            Assert (code < D_CODES, "bad d_code");
+    if (s->sym_next != 0)
+        do {
+            dist = s->sym_buf[sx++] & 0xff;
+            dist += (unsigned) (s->sym_buf[sx++] & 0xff) << 8;
+            lc = s->sym_buf[sx++];
+            if (dist == 0) {
+                send_code(s, lc, ltree); /* send a literal byte */
+                Tracecv(isgraph(lc), (stderr, " '%c' ", lc));
+            } else {
+                /* Here, lc is the match length - MIN_MATCH */
+                code = _length_code[lc];
+                send_code(s, code + LITERALS + 1, ltree);   /* send length code */
+                extra = extra_lbits[code];
+                if (extra != 0) {
+                    lc -= base_length[code];
+                    send_bits(s, lc, extra);       /* send the extra length bits */
+                }
+                dist--; /* dist is now the match distance - 1 */
+                code = d_code(dist);
+                Assert (code < D_CODES, "bad d_code");
 
-            send_code(s, code, dtree);       /* send the distance code */
-            extra = extra_dbits[code];
-            if (extra != 0) {
-                dist -= (unsigned)base_dist[code];
-                send_bits(s, dist, extra);   /* send the extra distance bits */
-            }
-        } /* literal or match pair ? */
+                send_code(s, code, dtree);       /* send the distance code */
+                extra = extra_dbits[code];
+                if (extra != 0) {
+                    dist -= (unsigned) base_dist[code];
+                    send_bits(s, dist, extra);   /* send the extra distance bits */
+                }
+            } /* literal or match pair ? */
 
-        /* Check that the overlay between pending_buf and sym_buf is ok: */
-        Assert(s->pending < s->lit_bufsize + sx, "pendingBuf overflow");
+            /* Check that the overlay between pending_buf and sym_buf is ok: */
+            Assert(s->pending < s->lit_bufsize + sx, "pendingBuf overflow");
 
-    } while (sx < s->sym_next);
+        } while (sx < s->sym_next);
 
     send_code(s, END_BLOCK, ltree);
 }
@@ -1099,9 +1093,7 @@ local void compress_block(s, ltree, dtree)
  *   (7 {BEL}, 8 {BS}, 11 {VT}, 12 {FF}, 26 {SUB}, 27 {ESC}).
  * IN assertion: the fields Freq of dyn_ltree are set.
  */
-local int detect_data_type(s)
-    deflate_state *s;
-{
+local int detect_data_type(deflate_state *s) {
     /* block_mask is the bit mask of block-listed bytes
      * set bits 0..6, 14..25, and 28..31
      * 0xf3ffc07f = binary 11110011111111111100000001111111
@@ -1116,7 +1108,7 @@ local int detect_data_type(s)
 
     /* Check for textual ("allow-listed") bytes. */
     if (s->dyn_ltree[9].Freq != 0 || s->dyn_ltree[10].Freq != 0
-            || s->dyn_ltree[13].Freq != 0)
+        || s->dyn_ltree[13].Freq != 0)
         return Z_TEXT;
     for (n = 32; n < LITERALS; n++)
         if (s->dyn_ltree[n].Freq != 0)
@@ -1133,10 +1125,8 @@ local int detect_data_type(s)
  * method would use a table)
  * IN assertion: 1 <= len <= 15
  */
-local unsigned bi_reverse(code, len)
-    unsigned code; /* the value to invert */
-    int len;       /* its bit length */
-{
+local unsigned bi_reverse(unsigned code, /* the value to invert */
+                          int len) {       /* its bit length */
     register unsigned res = 0;
     do {
         res |= code & 1;
@@ -1148,15 +1138,13 @@ local unsigned bi_reverse(code, len)
 /* ===========================================================================
  * Flush the bit buffer, keeping at most 7 bits in it.
  */
-local void bi_flush(s)
-    deflate_state *s;
-{
+local void bi_flush(deflate_state *s) {
     if (s->bi_valid == 16) {
         put_short(s, s->bi_buf);
         s->bi_buf = 0;
         s->bi_valid = 0;
     } else if (s->bi_valid >= 8) {
-        put_byte(s, (Byte)s->bi_buf);
+        put_byte(s, (Byte) s->bi_buf);
         s->bi_buf >>= 8;
         s->bi_valid -= 8;
     }
@@ -1165,13 +1153,11 @@ local void bi_flush(s)
 /* ===========================================================================
  * Flush the bit buffer and align the output on a byte boundary
  */
-local void bi_windup(s)
-    deflate_state *s;
-{
+local void bi_windup(deflate_state *s) {
     if (s->bi_valid > 8) {
         put_short(s, s->bi_buf);
     } else if (s->bi_valid > 0) {
-        put_byte(s, (Byte)s->bi_buf);
+        put_byte(s, (Byte) s->bi_buf);
     }
     s->bi_buf = 0;
     s->bi_valid = 0;

--- a/external/zlib/uncompr.c
+++ b/external/zlib/uncompr.c
@@ -6,6 +6,7 @@
 /* @(#) $Id$ */
 
 #define ZLIB_INTERNAL
+
 #include "zlib.h"
 
 /* ===========================================================================
@@ -24,15 +25,13 @@
    Z_DATA_ERROR if the input data was corrupted, including if the input data is
    an incomplete zlib stream.
 */
-int ZEXPORT uncompress2(dest, destLen, source, sourceLen)
-    Bytef *dest;
-    uLongf *destLen;
-    const Bytef *source;
-    uLong *sourceLen;
-{
+int ZEXPORT uncompress2(Bytef *dest,
+                        uLongf *destLen,
+                        const Bytef *source,
+                        uLong *sourceLen) {
     z_stream stream;
     int err;
-    const uInt max = (uInt)-1;
+    const uInt max = (uInt) -1;
     uLong len, left;
     Byte buf[1];    /* for detection of incomplete stream when *destLen == 0 */
 
@@ -40,17 +39,16 @@ int ZEXPORT uncompress2(dest, destLen, source, sourceLen)
     if (*destLen) {
         left = *destLen;
         *destLen = 0;
-    }
-    else {
+    } else {
         left = 1;
         dest = buf;
     }
 
-    stream.next_in = (z_const Bytef *)source;
+    stream.next_in = (z_const Bytef *) source;
     stream.avail_in = 0;
-    stream.zalloc = (alloc_func)0;
-    stream.zfree = (free_func)0;
-    stream.opaque = (voidpf)0;
+    stream.zalloc = (alloc_func) 0;
+    stream.zfree = (free_func) 0;
+    stream.opaque = (voidpf) 0;
 
     err = inflateInit(&stream);
     if (err != Z_OK) return err;
@@ -60,11 +58,11 @@ int ZEXPORT uncompress2(dest, destLen, source, sourceLen)
 
     do {
         if (stream.avail_out == 0) {
-            stream.avail_out = left > (uLong)max ? max : (uInt)left;
+            stream.avail_out = left > (uLong) max ? max : (uInt) left;
             left -= stream.avail_out;
         }
         if (stream.avail_in == 0) {
-            stream.avail_in = len > (uLong)max ? max : (uInt)len;
+            stream.avail_in = len > (uLong) max ? max : (uInt) len;
             len -= stream.avail_in;
         }
         err = inflate(&stream, Z_NO_FLUSH);
@@ -78,16 +76,14 @@ int ZEXPORT uncompress2(dest, destLen, source, sourceLen)
 
     inflateEnd(&stream);
     return err == Z_STREAM_END ? Z_OK :
-           err == Z_NEED_DICT ? Z_DATA_ERROR  :
+           err == Z_NEED_DICT ? Z_DATA_ERROR :
            err == Z_BUF_ERROR && left + stream.avail_out ? Z_DATA_ERROR :
            err;
 }
 
-int ZEXPORT uncompress(dest, destLen, source, sourceLen)
-    Bytef *dest;
-    uLongf *destLen;
-    const Bytef *source;
-    uLong sourceLen;
-{
+int ZEXPORT uncompress(Bytef *dest,
+                       uLongf *destLen,
+                       const Bytef *source,
+                       uLong sourceLen) {
     return uncompress2(dest, destLen, source, &sourceLen);
 }

--- a/external/zlib/zutil.c
+++ b/external/zlib/zutil.c
@@ -6,57 +6,82 @@
 /* @(#) $Id$ */
 
 #include "zutil.h"
+
 #ifndef Z_SOLO
+
 #  include "gzguts.h"
+
 #endif
 
-z_const char * const z_errmsg[10] = {
-    (z_const char *)"need dictionary",     /* Z_NEED_DICT       2  */
-    (z_const char *)"stream end",          /* Z_STREAM_END      1  */
-    (z_const char *)"",                    /* Z_OK              0  */
-    (z_const char *)"file error",          /* Z_ERRNO         (-1) */
-    (z_const char *)"stream error",        /* Z_STREAM_ERROR  (-2) */
-    (z_const char *)"data error",          /* Z_DATA_ERROR    (-3) */
-    (z_const char *)"insufficient memory", /* Z_MEM_ERROR     (-4) */
-    (z_const char *)"buffer error",        /* Z_BUF_ERROR     (-5) */
-    (z_const char *)"incompatible version",/* Z_VERSION_ERROR (-6) */
-    (z_const char *)""
+z_const char *const z_errmsg[10] = {
+        (z_const char *) "need dictionary",     /* Z_NEED_DICT       2  */
+        (z_const char *) "stream end",          /* Z_STREAM_END      1  */
+        (z_const char *) "",                    /* Z_OK              0  */
+        (z_const char *) "file error",          /* Z_ERRNO         (-1) */
+        (z_const char *) "stream error",        /* Z_STREAM_ERROR  (-2) */
+        (z_const char *) "data error",          /* Z_DATA_ERROR    (-3) */
+        (z_const char *) "insufficient memory", /* Z_MEM_ERROR     (-4) */
+        (z_const char *) "buffer error",        /* Z_BUF_ERROR     (-5) */
+        (z_const char *) "incompatible version",/* Z_VERSION_ERROR (-6) */
+        (z_const char *) ""
 };
 
 
-const char * ZEXPORT zlibVersion()
-{
+const char *ZEXPORT zlibVersion() {
     return ZLIB_VERSION;
 }
 
-uLong ZEXPORT zlibCompileFlags()
-{
+uLong ZEXPORT zlibCompileFlags() {
     uLong flags;
 
     flags = 0;
-    switch ((int)(sizeof(uInt))) {
-    case 2:     break;
-    case 4:     flags += 1;     break;
-    case 8:     flags += 2;     break;
-    default:    flags += 3;
+    switch ((int) (sizeof(uInt))) {
+        case 2:
+            break;
+        case 4:
+            flags += 1;
+            break;
+        case 8:
+            flags += 2;
+            break;
+        default:
+            flags += 3;
     }
-    switch ((int)(sizeof(uLong))) {
-    case 2:     break;
-    case 4:     flags += 1 << 2;        break;
-    case 8:     flags += 2 << 2;        break;
-    default:    flags += 3 << 2;
+    switch ((int) (sizeof(uLong))) {
+        case 2:
+            break;
+        case 4:
+            flags += 1 << 2;
+            break;
+        case 8:
+            flags += 2 << 2;
+            break;
+        default:
+            flags += 3 << 2;
     }
-    switch ((int)(sizeof(voidpf))) {
-    case 2:     break;
-    case 4:     flags += 1 << 4;        break;
-    case 8:     flags += 2 << 4;        break;
-    default:    flags += 3 << 4;
+    switch ((int) (sizeof(voidpf))) {
+        case 2:
+            break;
+        case 4:
+            flags += 1 << 4;
+            break;
+        case 8:
+            flags += 2 << 4;
+            break;
+        default:
+            flags += 3 << 4;
     }
-    switch ((int)(sizeof(z_off_t))) {
-    case 2:     break;
-    case 4:     flags += 1 << 6;        break;
-    case 8:     flags += 2 << 6;        break;
-    default:    flags += 3 << 6;
+    switch ((int) (sizeof(z_off_t))) {
+        case 2:
+            break;
+        case 4:
+            flags += 1 << 6;
+            break;
+        case 8:
+            flags += 2 << 6;
+            break;
+        default:
+            flags += 3 << 6;
     }
 #ifdef ZLIB_DEBUG
     flags += 1 << 8;
@@ -132,26 +157,24 @@ void ZLIB_INTERNAL z_error(m)
 /* exported to allow conversion of error code to string for compress() and
  * uncompress()
  */
-const char * ZEXPORT zError(err)
-    int err;
-{
+const char *ZEXPORT zError(int err) {
     return ERR_MSG(err);
 }
 
 #if defined(_WIN32_WCE) && _WIN32_WCE < 0x800
-    /* The older Microsoft C Run-Time Library for Windows CE doesn't have
-     * errno.  We define it as a global variable to simplify porting.
-     * Its value is always 0 and should not be used.
-     */
-    int errno = 0;
+/* The older Microsoft C Run-Time Library for Windows CE doesn't have
+ * errno.  We define it as a global variable to simplify porting.
+ * Its value is always 0 and should not be used.
+ */
+int errno = 0;
 #endif
 
 #ifndef HAVE_MEMCPY
 
 void ZLIB_INTERNAL zmemcpy(dest, source, len)
-    Bytef* dest;
-    const Bytef* source;
-    uInt  len;
+        Bytef *dest;
+        const Bytef *source;
+        uInt len;
 {
     if (len == 0) return;
     do {
@@ -160,21 +183,21 @@ void ZLIB_INTERNAL zmemcpy(dest, source, len)
 }
 
 int ZLIB_INTERNAL zmemcmp(s1, s2, len)
-    const Bytef* s1;
-    const Bytef* s2;
-    uInt  len;
+const Bytef *s1;
+      const Bytef *s2;
+      uInt len;
 {
     uInt j;
 
     for (j = 0; j < len; j++) {
-        if (s1[j] != s2[j]) return 2*(s1[j] > s2[j])-1;
+        if (s1[j] != s2[j]) return 2 * (s1[j] > s2[j]) - 1;
     }
     return 0;
 }
 
 void ZLIB_INTERNAL zmemzero(dest, len)
-    Bytef* dest;
-    uInt  len;
+        Bytef *dest;
+        uInt len;
 {
     if (len == 0) return;
     do {
@@ -299,26 +322,26 @@ void ZLIB_INTERNAL zcfree(voidpf opaque, voidpf ptr)
 #ifndef MY_ZCALLOC /* Any system without a special alloc function */
 
 #ifndef STDC
-extern voidp  malloc OF((uInt size));
-extern voidp  calloc OF((uInt items, uInt size));
-extern void   free   OF((voidpf ptr));
+
+extern voidp malloc OF((uInt size));
+
+extern voidp calloc OF((uInt items, uInt size));
+
+extern void free OF((voidpf ptr));
+
 #endif
 
-voidpf ZLIB_INTERNAL zcalloc(opaque, items, size)
-    voidpf opaque;
-    unsigned items;
-    unsigned size;
-{
-    (void)opaque;
-    return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
-                              (voidpf)calloc(items, size);
+voidpf ZLIB_INTERNAL zcalloc(voidpf opaque,
+                             unsigned items,
+                             unsigned size) {
+    (void) opaque;
+    return sizeof(uInt) > 2 ? (voidpf) malloc(items * size) :
+           (voidpf) calloc(items, size);
 }
 
-void ZLIB_INTERNAL zcfree(opaque, ptr)
-    voidpf opaque;
-    voidpf ptr;
-{
-    (void)opaque;
+void ZLIB_INTERNAL zcfree(voidpf opaque,
+                          voidpf ptr) {
+    (void) opaque;
     free(ptr);
 }
 

--- a/libmariadb/ma_context.c
+++ b/libmariadb/ma_context.c
@@ -47,9 +47,7 @@ union pass_void_ptr_as_2_int {
   the actual type (as the actual type can differ from call to call).
 */
 static void
-my_context_spawn_internal(i0, i1)
-int i0, i1;
-{
+my_context_spawn_internal(int i0, int i1) {
   int err;
   struct my_context *c;
   union pass_void_ptr_as_2_int u;


### PR DESCRIPTION
Refactor zlib functions to use modern prototype declaration and avoid warnings.

Updated the declaration of the `zlib` functions to use modern C++ syntax for specifying parameter types. This resolves a compiler warning about using an outdated function declaration style.

New Signature:
`uLong ZEXPORT adler32_z(uLong adler, const Bytef *buf, z_size_t len)`

This change improves code compatibility with modern C/C++ standards.