### PR TITLE
CONC-666: Fix memory allocation issue with prepared statement reexecution

### DIFF
--- a/libmariadb/ma_alloc.c
+++ b/libmariadb/ma_alloc.c
@@ -21,13 +21,14 @@
 #include <ma_sys.h>
 #include <ma_string.h>
 
+#define INIT_BLOCK_NUM 4
 void ma_init_alloc_root(MA_MEM_ROOT *mem_root, size_t block_size, size_t pre_alloc_size)
 {
   mem_root->free= mem_root->used= mem_root->pre_alloc= 0;
   mem_root->min_malloc=32;
   mem_root->block_size= (block_size-MALLOC_OVERHEAD-sizeof(MA_USED_MEM)+8);
   mem_root->error_handler=0;
-  mem_root->block_num= 4;
+  mem_root->block_num= INIT_BLOCK_NUM;
   mem_root->first_block_usage= 0;
 #if !(defined(HAVE_purify) && defined(EXTRA_DEBUG))
   if (pre_alloc_size)
@@ -141,6 +142,7 @@ void ma_free_root(MA_MEM_ROOT *root, myf MyFlags)
     root->free->left=root->pre_alloc->size-ALIGN_SIZE(sizeof(MA_USED_MEM));
     root->free->next=0;
   }
+  root->block_num= INIT_BLOCK_NUM;
 }
 
 


### PR DESCRIPTION
…tion.

Connector is using a memory root for the result set, and mysql_stmt_execute()/mysql_stmt_store_result(), when executed in a loop, leads to series of ma_alloc_root() and ma_free_root() calls for the same memory root.

The problem is that ma_alloc_root() calculates the allocation size based on MA_MEM_ROOT::block_num, this value is incremented for larger allocation, but is never reset. As a result, the allocation size continuously grows, for an empty memroot.

This patch resets MA_MEM_ROOT::block_num in ma_free_root().