### PR TITLE
Additional fix for CONC-668:

### DIFF
--- a/libmariadb/ma_context.c
+++ b/libmariadb/ma_context.c
@@ -90,6 +90,8 @@ my_context_spawn(struct my_context *c, void (*f)(void *), void *d)
 {
   int err;
   union pass_void_ptr_as_2_int u;
+  u.a[0]= 0;
+  u.a[1]= 0;
 
   err= getcontext(&c->spawned_context);
   if (err)


### PR DESCRIPTION
Fix build error on 32-bit systems.

```
/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-H3.arm-12.0-devel/build/mariadb-connector-c-3.3.7/libmariadb/ma_context.c: In function 'my_context_spawn':
/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-H3.arm-12.0-devel/build/mariadb-connector-c-3.3.7/libmariadb/ma_context.c:104:3: error: 'u.a[1]' may be used uninitialized [-Werror=maybe-uninitialized]
  104 |   makecontext(&c->spawned_context, my_context_spawn_internal, 2,
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |               u.a[0], u.a[1]);
      |               ~~~~~~~~~~~~~~~
/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-H3.arm-12.0-devel/build/mariadb-connector-c-3.3.7/libmariadb/ma_context.c:92:32: note: 'u.a[1]' was declared here
   92 |   union pass_void_ptr_as_2_int u;
      |                                ^
cc1: all warnings being treated as errors
[107/142] Building C object unittest/libmariadb/CMakeFiles/ps_bugs.dir/ps_bugs.c.o
ninja: build stopped: subcommand failed.
```