### PR TITLE
ARM 32-bit platforms are getting a bad handshake error

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -123,7 +123,7 @@ extern int mthd_stmt_fetch_to_bind(MYSQL_STMT *stmt, unsigned char *row);
 extern int mthd_stmt_read_all_rows(MYSQL_STMT *stmt);
 extern void mthd_stmt_flush_unbuffered(MYSQL_STMT *stmt);
 extern my_bool _mariadb_read_options(MYSQL *mysql, const char *dir, const char *config_file, const char *group, unsigned int recursion);
-extern unsigned char *mysql_net_store_length(unsigned char *packet, ulonglong length);
+extern unsigned char *mysql_net_store_length(unsigned char *packet, size_t length);
 
 extern void
 my_context_install_suspend_resume_hook(struct mysql_async_context *b,

--- a/libmariadb/mariadb_stmt.c
+++ b/libmariadb/mariadb_stmt.c
@@ -492,7 +492,7 @@ MYSQL_RES *_mysql_stmt_use_result(MYSQL_STMT *stmt)
   return(NULL);
 }
 
-unsigned char *mysql_net_store_length(unsigned char *packet, ulonglong length)
+unsigned char *mysql_net_store_length(unsigned char *packet, size_t length)
 {
   if (length < (unsigned long long) L64(251)) {
     *packet = (unsigned char) length;

--- a/libmariadb/mariadb_stmt.c
+++ b/libmariadb/mariadb_stmt.c
@@ -511,7 +511,7 @@ unsigned char *mysql_net_store_length(unsigned char *packet, size_t length)
     return packet + 3;
   }
   *packet++ = 254;
-  int8store(packet, length);
+  int8store(packet,(ulonglong) length);
   return packet + 8;
 }
 


### PR DESCRIPTION
This issue does not occur on 3.3.6, and appears to be caused by commit https://github.com/mariadb-corporation/mariadb-connector-c/commit/9f37c27bc8921ddc7e65ba8fc75cb4993380228a.

The solution that seems to work on arm & aarch64 is casting length to ulonglong before calling int8store.  Runtime tested on arm & aarch64 platforms.