### PR TITLE
Add support to ZSTD as static library

### DIFF
--- a/cmake/FindZStd.cmake
+++ b/cmake/FindZStd.cmake
@@ -10,7 +10,7 @@ find_path(ZSTD_INCLUDE_DIRS
   HINTS ${ZSTD_ROOT_DIR}/include)
 
 find_library(ZSTD_LIBRARIES
-  NAMES zstd
+  NAMES zstd zstd_static
   HINTS ${ZSTD_ROOT_DIR}/lib)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
The ZSTD library uses `zstd_static` as name when is static:

https://github.com/facebook/zstd/blob/dev/build/cmake/lib/CMakeLists.txt#L161

Without this change, is not possible to find zstd on Windows, for instance, because the current `FindZstd.cmake` expects `zstd` as library name only.