### PR TITLE
Fix -Wcalloc-transposed-args

### DIFF
--- a/plugins/io/remote_io.c
+++ b/plugins/io/remote_io.c
@@ -279,11 +279,11 @@ MA_FILE *ma_rio_open(const char *url,const char *operation)
   MA_REMOTE_FILE *rf;
   (void)operation;
  
-  if (!(file = (MA_FILE *)calloc(sizeof(MA_FILE), 1)))
+  if (!(file = (MA_FILE *)calloc(1, sizeof(MA_FILE))))
     return NULL;
  
   file->type= MA_FILE_REMOTE;
-  if (!(file->ptr= rf= (MA_REMOTE_FILE *)calloc(sizeof(MA_REMOTE_FILE), 1)))
+  if (!(file->ptr= rf= (MA_REMOTE_FILE *)calloc(1, sizeof(MA_REMOTE_FILE))))
   {
     free(file);
     return NULL; 

--- a/plugins/trace/trace_example.c
+++ b/plugins/trace/trace_example.c
@@ -132,7 +132,7 @@ static TRACE_INFO *get_trace_info(unsigned long thread_id)
       info= (TRACE_INFO *)info->next;
   }
 
-  if (!(info= (TRACE_INFO *)calloc(sizeof(TRACE_INFO), 1)))
+  if (!(info= (TRACE_INFO *)calloc(1, sizeof(TRACE_INFO))))
     return NULL;
   info->thread_id= thread_id;
   info->next= trace_info;

--- a/unittest/libmariadb/bulk1.c
+++ b/unittest/libmariadb/bulk1.c
@@ -74,8 +74,8 @@ static int bulk1(MYSQL *mysql)
 
   /* allocate memory */
   buffer= calloc(TEST_ARRAY_SIZE, sizeof(char *));
-  lengths= (unsigned long *)calloc(sizeof(long), TEST_ARRAY_SIZE);
-  vals= (unsigned int *)calloc(sizeof(int), TEST_ARRAY_SIZE);
+  lengths= (unsigned long *)calloc(TEST_ARRAY_SIZE, sizeof(long));
+  vals= (unsigned int *)calloc(TEST_ARRAY_SIZE, sizeof(int));
 
   for (i=0; i < TEST_ARRAY_SIZE; i++)
   {

--- a/unittest/libmariadb/ps_bugs.c
+++ b/unittest/libmariadb/ps_bugs.c
@@ -5159,7 +5159,7 @@ static int test_maxparam(MYSQL *mysql)
   MYSQL_STMT *stmt= mysql_stmt_init(mysql);
   MYSQL_BIND* bind;
 
-  bind = calloc(sizeof(MYSQL_BIND), 65535);
+  bind = calloc(65535, sizeof(MYSQL_BIND));
 
   rc= mysql_query(mysql, "DROP TABLE IF EXISTS t1");
   check_mysql_rc(rc, mysql);


### PR DESCRIPTION
Fixes warnings like:
```
unittest/libmariadb/bulk1.c: In function ‘bulk1’:
unittest/libmariadb/bulk1.c:77:43: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
   77 |   lengths= (unsigned long *)calloc(sizeof(long), TEST_ARRAY_SIZE);
      |                                           ^~~~
unittest/libmariadb/bulk1.c:77:43: note: earlier argument should specify number of elements, later size of each element
unittest/libmariadb/bulk1.c:78:39: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argu
ment and not in the later argument [-Werror=calloc-transposed-args]
   78 |   vals= (unsigned int *)calloc(sizeof(int), TEST_ARRAY_SIZE);
      |                                       ^~~
```

The calloc prototype is:
```
void *calloc(size_t nmemb, size_t size);
```

So, just swap the number of members and size arguments to match the prototype, as we're initialising N struct of size Y. GCC then sees we're not doing anything wrong.