### PR TITLE
CONC-693 Fix SSL_read/write return value checking in ma_tls_async_check_result

### DIFF
--- a/libmariadb/mariadb_async.c
+++ b/libmariadb/mariadb_async.c
@@ -140,7 +140,7 @@ my_ssl_async_check_result(int res, struct mysql_async_context *b, MARIADB_SSL *c
 {
   int ssl_err;
   b->events_to_wait_for= 0;
-  if (res >= 0)
+  if (res > 0)
     return 1;
   ssl_err= SSL_get_error(ssl, res);
   if (ssl_err == SSL_ERROR_WANT_READ)

--- a/libmariadb/secure/openssl.c
+++ b/libmariadb/secure/openssl.c
@@ -529,7 +529,7 @@ ma_tls_async_check_result(int res, struct mysql_async_context *b, SSL *ssl)
 {
   int ssl_err;
   b->events_to_wait_for= 0;
-  if (res >= 0)
+  if (res > 0)
     return 1;
   ssl_err= SSL_get_error(ssl, res);
   if (ssl_err == SSL_ERROR_WANT_READ)


### PR DESCRIPTION
SSL_{read,write}'s return values == 0 signify the operation was unsuccessful, but here it's being treated as success. Other calls of these functions already properly checks the return value.

Please note I found this through code inspection while trying to debug a different issue. I do not have a case where this can be hit, but in principle this should be fixed. Link to openssl man page showing return values <= 0 signify an error https://www.openssl.org/docs/manmaster/man3/SSL_read.html