### PR TITLE
Fix `sys/poll.h` -> `poll.h`

### DIFF
--- a/plugins/pvio/pvio_socket.c
+++ b/plugins/pvio/pvio_socket.c
@@ -39,7 +39,7 @@
 #include <sys/un.h>
 #endif
 #ifdef HAVE_POLL
-#include <sys/poll.h>
+#include <poll.h>
 #endif
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>


### PR DESCRIPTION
See https://pubs.opengroup.org/onlinepubs/7908799/xsh/poll.h.html, or the [other files in this project](https://github.com/search?q=repo%3Amariadb-corporation%2Fmariadb-connector-c%20poll.h&type=code) referencing `poll.h`:
```console
% grep -r 'poll.h'                                                    
libmariadb/ma_net.c:#include <poll.h>
libmariadb/mariadb_lib.c:#include <poll.h>
plugins/pvio/pvio_socket.c:#include <sys/poll.h>
unittest/libmariadb/async.c:#include <poll.h>
```