### PR TITLE
[CONC-700] fix calloc errors as warnings when compiling with gcc-14.1.0

### DIFF
--- a/unittest/libmariadb/bulk1.c
+++ b/unittest/libmariadb/bulk1.c
@@ -723,7 +723,7 @@ static int test_char_conv2(MYSQL *mysql)
     return SKIP;
 
   stmt= mysql_stmt_init(mysql);
-  buffer[0]= calloc(1, 7);
+  buffer[0]= calloc(7, 1);
   strcpy (buffer[0], "\xC3\x82\xC3\x83\xC3\x84\x00");
 
   rc= mysql_query(mysql, "SET NAMES UTF8");
@@ -1126,7 +1126,7 @@ static int bulk_with_unit_result_insert(MYSQL *my)
 
   /* allocate memory */
   buffer= calloc(TEST_ARRAY_SIZE, sizeof(char *));
-  lengths= (unsigned long *)calloc(sizeof(long), TEST_ARRAY_SIZE);
+  lengths= (unsigned long *)calloc(TEST_ARRAY_SIZE, sizeof(long));
 
   for (i=0; i < TEST_ARRAY_SIZE; i++)
   {
@@ -1251,7 +1251,7 @@ static int bulk_with_unit_result_delete(MYSQL *my)
   rc= mysql_stmt_attr_set(stmt, STMT_ATTR_ARRAY_SIZE, &array_size);
   check_stmt_rc(rc, stmt);
 
-  vals= (unsigned int *)calloc(sizeof(int), 5);
+  vals= (unsigned int *)calloc(5, sizeof(int));
   memset(bind, 0, sizeof(MYSQL_BIND) * 1);
   bind[0].buffer_type= MYSQL_TYPE_LONG;
   bind[0].buffer= vals;
@@ -1359,7 +1359,7 @@ static int bulk_with_unit_result_update(MYSQL *my)
   rc= mysql_stmt_attr_set(stmt, STMT_ATTR_ARRAY_SIZE, &array_size);
   check_stmt_rc(rc, stmt);
 
-  vals= (unsigned int *)calloc(sizeof(int), 5);
+  vals= (unsigned int *)calloc(5, sizeof(int));
   memset(bind, 0, sizeof(MYSQL_BIND) * 1);
   bind[0].buffer_type= MYSQL_TYPE_LONG;
   bind[0].buffer= vals;


### PR DESCRIPTION
ref: https://jira.mariadb.org/browse/CONC-700

error: 'calloc' sizes specified with 'sizeof' in the earlier argument
  and not in the later argument [-Werror=calloc-transposed-args]
note: earlier argument should specify number of elements, later size
  of each element

fixes:
```
Executing (target): ninja 
[144/145] Building C object unittest/libmariadb/CMakeFiles/bulk1.dir/bulk1.c.o
FAILED: unittest/libmariadb/CMakeFiles/bulk1.dir/bulk1.c.o 
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc -DHAVE_OPENSSL -DHAVE_REMOTEIO=1 -DHAVE_TLS -DLIBMARIADB -DMARIADB_MACHINE_TYPE=\"x86_64\" -DMARIADB_SYSTEM_TYPE=\"Linux\" -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/mariadb-connector-c-3.4.0/.x86_64-libreelec-linux-gnu/include -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/mariadb-connector-c-3.4.0/plugins/auth -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/mariadb-connector-c-3.4.0/include -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/mariadb-connector-c-3.4.0/plugins/compress -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/mariadb-connector-c-3.4.0/plugins/pvio -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/mariadb-connector-c-3.4.0/unittest/mytap -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/mariadb-connector-c-3.4.0/unittest/libmariadb -march=x86-64-v3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -Wunused -Wlogical-op -Wno-uninitialized -Wall -Wextra -Wformat-security -Wno-init-self -Wwrite-strings -Wshift-count-overflow -Wdeclaration-after-statement -Wno-undef -Wno-unknown-pragmas -Wno-stringop-truncation -Werror  -DDBUG_OFF -MD -MT unittest/libmariadb/CMakeFiles/bulk1.dir/bulk1.c.o -MF unittest/libmariadb/CMakeFiles/bulk1.dir/bulk1.c.o.d -o unittest/libmariadb/CMakeFiles/bulk1.dir/bulk1.c.o -c /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/mariadb-connector-c-3.4.0/unittest/libmariadb/bulk1.c
../unittest/libmariadb/bulk1.c: In function 'bulk_with_unit_result_insert':
../unittest/libmariadb/bulk1.c:1129:43: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
 1129 |   lengths= (unsigned long *)calloc(sizeof(long), TEST_ARRAY_SIZE);
      |                                           ^~~~
../unittest/libmariadb/bulk1.c:1129:43: note: earlier argument should specify number of elements, later size of each element
../unittest/libmariadb/bulk1.c: In function 'bulk_with_unit_result_delete':
../unittest/libmariadb/bulk1.c:1254:39: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
 1254 |   vals= (unsigned int *)calloc(sizeof(int), 5);
      |                                       ^~~
../unittest/libmariadb/bulk1.c:1254:39: note: earlier argument should specify number of elements, later size of each element
../unittest/libmariadb/bulk1.c: In function 'bulk_with_unit_result_update':
../unittest/libmariadb/bulk1.c:1362:39: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
 1362 |   vals= (unsigned int *)calloc(sizeof(int), 5);
      |                                       ^~~
../unittest/libmariadb/bulk1.c:1362:39: note: earlier argument should specify number of elements, later size of each element
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```