### PR TITLE
Fix usage of wait_io_or_timeout from TLS layers

### DIFF
--- a/libmariadb/secure/gnutls.c
+++ b/libmariadb/secure/gnutls.c
@@ -1313,7 +1313,7 @@ ssize_t ma_tls_read(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
   {
     if (rc != GNUTLS_E_AGAIN && rc != GNUTLS_E_INTERRUPTED)
       break;
-    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->mysql->options.read_timeout) < 1)
+    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_READ_TIMEOUT]) < 1)
       break;
   }
   if (rc <= 0) {
@@ -1332,7 +1332,7 @@ ssize_t ma_tls_write(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
   {
     if (rc != GNUTLS_E_AGAIN && rc != GNUTLS_E_INTERRUPTED)
       break;
-    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->mysql->options.write_timeout) < 1)
+    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_WRITE_TIMEOUT]) < 1)
       break;
   }
   if (rc <= 0) {

--- a/libmariadb/secure/openssl.c
+++ b/libmariadb/secure/openssl.c
@@ -494,11 +494,11 @@ my_bool ma_tls_connect(MARIADB_TLS *ctls)
   {
     switch((SSL_get_error(ssl, rc))) {
     case SSL_ERROR_WANT_READ:
-      if (pvio->methods->wait_io_or_timeout(pvio, TRUE, mysql->options.connect_timeout) < 1)
+      if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_CONNECT_TIMEOUT]) < 1)
         try_connect= 0;
       break;
     case SSL_ERROR_WANT_WRITE:
-      if (pvio->methods->wait_io_or_timeout(pvio, TRUE, mysql->options.connect_timeout) < 1)
+      if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_CONNECT_TIMEOUT]) < 1)
         try_connect= 0;
       break;
     default:
@@ -635,7 +635,7 @@ ssize_t ma_tls_read(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
     int error= SSL_get_error((SSL *)ctls->ssl, rc);
     if (error != SSL_ERROR_WANT_READ)
       break;
-    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->mysql->options.read_timeout) < 1)
+    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_READ_TIMEOUT]) < 1)
       break;
   }
   if (rc <= 0)
@@ -656,7 +656,7 @@ ssize_t ma_tls_write(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
     int error= SSL_get_error((SSL *)ctls->ssl, rc);
     if (error != SSL_ERROR_WANT_WRITE)
       break;
-    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->mysql->options.write_timeout) < 1)
+    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_WRITE_TIMEOUT]) < 1)
       break;
   }
   if (rc <= 0)


### PR DESCRIPTION
wait_io_or_timeout() accepts milliseconds, while options has seconds, since this is just plain MYSQL_OPT_READ_TIMEOUT/...

The one that has milliseconds are pvio->timeout[PVIO_*_TIMEOUT], so use them.

Usually this is not a problem, but, in case of interrupt (i.e. signal - EINTR) SSL_read() will return SSL_ERROR_WANT_READ/SSL_ERROR_WANT_WRITE, and then wait_io_or_timeout() will be called, and timeout will be wrong, may cause a failure.

This issue is required for ClickHouse - https://github.com/ClickHouse/ClickHouse/pull/65938