### PR TITLE
Update ma_context.c

### DIFF
--- a/libmariadb/ma_context.c
+++ b/libmariadb/ma_context.c
@@ -102,6 +102,8 @@ my_context_spawn(struct my_context *c, void (*f)(void *), void *d)
   c->user_func= f;
   c->user_data= d;
   c->active= 1;
+  u.a[0]= 0;
+  u.a[1]= 0; 
   u.p= c;
   makecontext(&c->spawned_context, (uc_func_t)my_context_spawn_internal, 2,
               u.a[0], u.a[1]);


### PR DESCRIPTION
Initializes the elements before they are used. I received this error when installing this on RPIos from cloning the repository.