### PR TITLE
Revert "Fix usage of wait_io_or_timeout from TLS layers"

### DIFF
--- a/libmariadb/secure/gnutls.c
+++ b/libmariadb/secure/gnutls.c
@@ -1365,7 +1365,7 @@ ssize_t ma_tls_read(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
   {
     if (rc != GNUTLS_E_AGAIN && rc != GNUTLS_E_INTERRUPTED)
       break;
-    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_READ_TIMEOUT]) < 1)
+    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->mysql->options.read_timeout) < 1)
       break;
   }
   if (rc <= 0) {
@@ -1384,7 +1384,7 @@ ssize_t ma_tls_write(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
   {
     if (rc != GNUTLS_E_AGAIN && rc != GNUTLS_E_INTERRUPTED)
       break;
-    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_WRITE_TIMEOUT]) < 1)
+    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->mysql->options.write_timeout) < 1)
       break;
   }
   if (rc <= 0) {

--- a/libmariadb/secure/openssl.c
+++ b/libmariadb/secure/openssl.c
@@ -567,11 +567,11 @@ my_bool ma_tls_connect(MARIADB_TLS *ctls)
   {
     switch((SSL_get_error(ssl, rc))) {
     case SSL_ERROR_WANT_READ:
-      if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_CONNECT_TIMEOUT]) < 1)
+      if (pvio->methods->wait_io_or_timeout(pvio, TRUE, mysql->options.connect_timeout) < 1)
         try_connect= 0;
       break;
     case SSL_ERROR_WANT_WRITE:
-      if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_CONNECT_TIMEOUT]) < 1)
+      if (pvio->methods->wait_io_or_timeout(pvio, TRUE, mysql->options.connect_timeout) < 1)
         try_connect= 0;
       break;
     default:
@@ -655,7 +655,7 @@ ssize_t ma_tls_read(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
     int error= SSL_get_error((SSL *)ctls->ssl, rc);
     if (error != SSL_ERROR_WANT_READ)
       break;
-    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_READ_TIMEOUT]) < 1)
+    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->mysql->options.read_timeout) < 1)
       break;
   }
   if (rc <= 0)
@@ -676,7 +676,7 @@ ssize_t ma_tls_write(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
     int error= SSL_get_error((SSL *)ctls->ssl, rc);
     if (error != SSL_ERROR_WANT_WRITE)
       break;
-    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_WRITE_TIMEOUT]) < 1)
+    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->mysql->options.write_timeout) < 1)
       break;
   }
   if (rc <= 0)


### PR DESCRIPTION
Reverts mariadb-corporation/mariadb-connector-c#250

Merged by mistake. Timeouts were already set via setsockopt() function before. Since the socket already timeout, it will wait andother read/write timeout period.
Instead of, we should get wait_io_or_timeout with a timeout of a few milliseconds to get the correct errno.