### PR TITLE
CONC-738: Fix zstd compression level bytes

### DIFF
--- a/plugins/auth/my_auth.c
+++ b/plugins/auth/my_auth.c
@@ -407,8 +407,7 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
   */
   if (mysql->client_flag & CLIENT_ZSTD_COMPRESSION)
   {
-    int4store(end, (unsigned int)3);
-    end+= 4;
+    *end++= 3;
   }
 
   /* Write authentication package */


### PR DESCRIPTION
The MySQL protocol documentation as well as the comments in code state that the compression level is stored in one byte. The code, however, used four bytes.