### PR TITLE
CONC-741: Check that MYSQL_STMT is not null

### DIFF
--- a/libmariadb/mariadb_stmt.c
+++ b/libmariadb/mariadb_stmt.c
@@ -129,7 +129,7 @@ static my_bool madb_have_pending_results(MYSQL_STMT *stmt)
 {
   LIST *li_stmt;
 
-  if (!stmt->mysql)
+  if (!stmt || !stmt->mysql)
     return 0;
 
   li_stmt= stmt->mysql->stmts;

--- a/unittest/libmariadb/misc.c
+++ b/unittest/libmariadb/misc.c
@@ -1662,6 +1662,13 @@ static int test_disable_tls1_0(MYSQL *my __attribute__((unused)))
   return OK;
 }
 
+static int test_null_handles(MYSQL *)
+{
+  mysql_close(NULL);
+  mysql_stmt_close(NULL);
+  return OK;
+}
+
 
 struct my_tests_st my_tests[] = {
   {"test_disable_tls1_0", test_disable_tls1_0, TEST_CONNECTION_DEFAULT, 0, NULL, NULL},
@@ -1707,7 +1714,8 @@ struct my_tests_st my_tests[] = {
   {"test_ldi_path", test_ldi_path, TEST_CONNECTION_NEW, 0, NULL, NULL},
 #ifdef _WIN32
   {"test_conc44", test_conc44, TEST_CONNECTION_NEW, 0, NULL, NULL},
-#endif 
+#endif
+  {"test_null_handles", test_null_handles, TEST_CONNECTION_NONE, 0, NULL, NULL},
   {NULL, NULL, 0, 0, NULL, 0}
 };
 


### PR DESCRIPTION
The code now again allows null MYSQL_STMT handles to be passed to mysql_stmt_close(). Added a sanity check test case that should guard against this happening in the future.