### PR TITLE
CONC-750 unit.pfs_instr-oom fails on mac with dynamic-stack-overflow

### DIFF
--- a/mariadb_config/mariadb_config.c.in
+++ b/mariadb_config/mariadb_config.c.in
@@ -175,7 +175,9 @@ static void mariadb_get_install_location()
     goto end;
   else {
 #if defined(__APPLE__)
-    unsigned int len= PATH_MAX;
+    // If reading the path was successful, then *bufsize is
+    // unchanged.
+    unsigned int len= PATH_MAX - 1;
     if (_NSGetExecutablePath(p, &len) != 0)
       *p= 0;
     else


### PR DESCRIPTION
Write a NULL byte at end of the array used for reading the executable name, not at one past the end of the array.