### PR TITLE
Avoid redfine of IO_SIZE if made configurable

### DIFF
--- a/include/ma_global.h
+++ b/include/ma_global.h
@@ -433,12 +433,6 @@ typedef SOCKET_SIZE_TYPE size_socket;
 /* #define FN_UPPER_CASE TRUE */
 
 /*
-  Io buffer size; Must be a power of 2 and a multiple of 512. May be
-  smaller what the disk page size. This influences the speed of the
-  isam btree library. eg to big to slow.
-*/
-#define IO_SIZE			4096
-/*
   How much overhead does malloc have. The code often allocates
   something like 1024-MALLOC_OVERHEAD bytes
 */

--- a/libmariadb/ma_net.c
+++ b/libmariadb/ma_net.c
@@ -41,6 +41,11 @@
 
 #define MAX_PACKET_LENGTH (256L*256L*256L-1)
 
+#ifndef NET_BUF_ALIGN
+#define NET_BUF_ALIGN 4096U
+#endif
+#define align_network_buffer(len) (((len)+NET_BUF_ALIGN-1) & ~(NET_BUF_ALIGN-1))
+
 /* net_buffer_length and max_allowed_packet are defined in mysql.h
    See bug conc-57
  */
@@ -128,7 +133,7 @@ static my_bool net_realloc(NET *net, size_t length)
     net->last_errno=ER_NET_PACKET_TOO_LARGE;
     return(1);
   }
-  pkt_length = (length+IO_SIZE-1) & ~(IO_SIZE-1);
+  pkt_length = align_network_buffer(length);
   /* reallocate buffer:
      size= pkt_length + NET_HEADER_SIZE + COMP_HEADER_SIZE */
   if (!(buff=(uchar*) realloc(net->buff, 


### PR DESCRIPTION
**This PR Closed and replaced by: https://github.com/mariadb-corporation/mariadb-connector-c/pull/267**

If the server is to make IO_SIZE configurable, we need to avoid either redefining it, or defining it to be different.

See: https://github.com/MariaDB/server/pull/3726 and https://jira.mariadb.org/browse/MDEV-35740