### PR TITLE
CONC-766: Disable clang -Wcast-function-type-strict for makecontext

### DIFF
--- a/libmariadb/ma_context.c
+++ b/libmariadb/ma_context.c
@@ -103,8 +103,21 @@ my_context_spawn(struct my_context *c, void (*f)(void *), void *d)
   c->user_data= d;
   c->active= 1;
   u.p= c;
+  /*
+    makecontext function expects function pointer to receive multiple
+    ints as an arguments, however is declared in ucontext.h header with
+    a void (empty) argument list. Ignore clang cast-function-type-strict
+    warning for this function call.
+  */
+# ifdef __clang__
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wcast-function-type-strict"
+# endif
   makecontext(&c->spawned_context, (uc_func_t)my_context_spawn_internal, 2,
               u.a[0], u.a[1]);
+# ifdef __clang__
+#  pragma clang diagnostic pop
+# endif
 
   return my_context_continue(c);
 }


### PR DESCRIPTION
makecontext has a defined prototype in ucontext.h that differs from its expected usage. Disable the clang warning for this function call.

Modelled off the af4498b776b1703a00cbb4f86ead0d0e4f5332bb commit.