### PR TITLE
travis: checkout PR using correct ref

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -35,7 +35,7 @@ if [ -n "$server_branch" ] ; then
   if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
     git submodule update --init --remote libmariadb
     cd libmariadb
-    git fetch origin ${TRAVIS_PULL_REQUEST}
+    git fetch origin pull/${TRAVIS_PULL_REQUEST}/head
     git checkout -qf FETCH_HEAD
   else
     git submodule set-branch -b ${TRAVIS_BRANCH} libmariadb


### PR DESCRIPTION
noticed test failure on https://app.travis-ci.com/github/mariadb-corporation/mariadb-connector-c/jobs/633073616 was pulling the wrong reference.

correct reference is pull/ID/head per
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally

pull/ID/merge is there but is aggressively cached and force pushes can be triggered on the old ref. see: https://jira.mariadb.org/browse/MDBF-1014