### PR TITLE
Static analysis fix

### DIFF
--- a/libmariadb/ma_io.c
+++ b/libmariadb/ma_io.c
@@ -165,11 +165,9 @@ int ma_feof(MA_FILE *file)
   switch (file->type) {
   case MA_FILE_LOCAL:
     return feof((FILE *)file->ptr);
-    break;
 #ifdef HAVE_REMOTEIO
   case MA_FILE_REMOTE:
     return rio_plugin->methods->mfeof(file);
-    break;
 #endif
   default:
     return -1;
@@ -188,11 +186,9 @@ size_t ma_read(void *ptr, size_t size, size_t nmemb, MA_FILE *file)
   case MA_FILE_LOCAL:
     s= fread(ptr, size, nmemb, (FILE *)file->ptr);
     return s;
-    break;
 #ifdef HAVE_REMOTEIO
   case MA_FILE_REMOTE:
     return rio_plugin->methods->mread(ptr, size, nmemb, file);
-    break;
 #endif
   default:
     return -1;
@@ -209,11 +205,9 @@ char *ma_gets(char *ptr, size_t size, MA_FILE *file)
   switch (file->type) {
   case MA_FILE_LOCAL:
     return fgets(ptr, (int)size, (FILE *)file->ptr);
-    break;
 #ifdef HAVE_REMOTEIO
   case MA_FILE_REMOTE:
     return rio_plugin->methods->mgets(ptr, size, file);
-    break;
 #endif
   default:
     return NULL;

--- a/libmariadb/ma_stmt_codec.c
+++ b/libmariadb/ma_stmt_codec.c
@@ -571,7 +571,6 @@ static void convert_froma_string(MYSQL_BIND *r_param, char *buffer, size_t len)
       str_to_TIME(buffer, len, tm);
       break;
     }
-    break;
     case MYSQL_TYPE_TINY_BLOB:
     case MYSQL_TYPE_MEDIUM_BLOB:
     case MYSQL_TYPE_LONG_BLOB:

--- a/libmariadb/ma_time.c
+++ b/libmariadb/ma_time.c
@@ -52,7 +52,6 @@ size_t mariadb_time_to_string(const MYSQL_TIME *tm, char *time_str, size_t len,
     default:
       time_str[0]= '\0';
       return 0;
-      break;
   }
   if (digits && len > length + 1)
     length+= snprintf(time_str + length, len - length, ".%0*lu", digits,

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -1357,7 +1357,11 @@ mysql_init(MYSQL *mysql)
   return mysql;
 error:
   if (mysql->free_me)
+  {
+    if (mysql->net.extension)
+      free(mysql->net.extension);
     free(mysql);
+  }
   return 0;
 }
 

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -810,7 +810,6 @@ my_bool _mariadb_set_conf_option(MYSQL *mysql, const char *config_option, const 
         switch (mariadb_defaults[i].type) {
         case MARIADB_OPTION_FUNC:
           return mariadb_defaults[i].u.option_func(mysql, config_option, config_value, -1);
-          break;
         case MARIADB_OPTION_BOOL:
           val_bool= 0;
           if (config_value)
@@ -929,7 +928,6 @@ static int parse_connection_string(MYSQL *mysql, const char *unused __attribute_
         if (pos <= end)
           val= pos;
         continue;
-        break;
       case ';':
         if (in_curly_brace)
         {
@@ -943,7 +941,6 @@ static int parse_connection_string(MYSQL *mysql, const char *unused __attribute_
           _mariadb_set_conf_option(mysql, key, val);
         key= val= NULL;
         continue;
-        break;
     }
     if (!key && *pos)
       key= pos;

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -2111,7 +2111,14 @@ my_bool STDCALL mariadb_reconnect(MYSQL *mysql)
     return(1);
   }
 
-  mysql_init(&tmp_mysql);
+  if (!mysql_init(&tmp_mysql))
+  {
+    /* extensions may have failed to allocate */
+    SET_CLIENT_ERROR(mysql, CR_OUT_OF_MEMORY, SQLSTATE_UNKNOWN, 0);
+    tmp_mysql.free_me= 0;
+    mysql_close(&tmp_mysql);
+    return(1);
+  }
   tmp_mysql.free_me= 0;
   tmp_mysql.options=mysql->options;
   if (mysql->extension->conn_hdlr)

--- a/libmariadb/mariadb_rpl.c
+++ b/libmariadb/mariadb_rpl.c
@@ -1166,7 +1166,6 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
     case UNKNOWN_EVENT:
     case SLAVE_EVENT:
        return rpl_event;
-       break;
     case HEARTBEAT_LOG_EVENT:
       /* no post header size */
       RPL_CHECK_POS(ev, ev_end, 11);
@@ -1898,7 +1897,6 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
         return 0;
       }
       return rpl_event;
-      break;
     }
 
     /* check if we have to send acknowledgement to primary
@@ -2092,7 +2090,6 @@ int STDCALL mariadb_rpl_get_optionsv(MARIADB_RPL *rpl,
   default:
     va_end(ap);
     return 1;
-    break;
   }
   va_end(ap);
   return 0;

--- a/libmariadb/mariadb_rpl.c
+++ b/libmariadb/mariadb_rpl.c
@@ -119,7 +119,6 @@ void rpl_set_error(MARIADB_RPL *rpl,
 
   const char *errmsg;
 
-  return;
   if (!format)
   {
     if (error_nr >= CR_MIN_ERROR && error_nr <= CR_MYSQL_LAST_ERROR)

--- a/libmariadb/mariadb_stmt.c
+++ b/libmariadb/mariadb_stmt.c
@@ -152,10 +152,8 @@ my_bool mthd_supported_buffer_type(enum enum_field_types type)
   case MYSQL_TYPE_VAR_STRING:
   case MYSQL_TYPE_YEAR:
     return 1;
-    break;
   default:
     return 0;
-    break;
   }
 }
 
@@ -1349,7 +1347,6 @@ my_bool STDCALL mysql_stmt_bind_param(MYSQL_STMT *stmt, MYSQL_BIND *bind)
       default:
         stmt_set_error(stmt, CR_UNSUPPORTED_PARAM_TYPE, SQLSTATE_UNKNOWN, 0);
         return(1);
-        break;
       }
     }
   }


### PR DESCRIPTION
Clean up a few things that would otherwise get caught by static analysis.

Not sure why `rpl_set_error` was disabled with a return.