### PR TITLE
get_tty_password(Windows) - CreateFile error

### DIFF
--- a/libmariadb/get_password.c
+++ b/libmariadb/get_password.c
@@ -122,11 +122,11 @@ char* get_tty_password(char *prompt, char *buffer, int length)
   if (prompt)
     fprintf(stderr, "%s", prompt);
 
-  if (!(Hdl= CreateFile("CONIN$", 
-                        GENERIC_READ | GENERIC_WRITE,
-                        FILE_SHARE_READ,
-                        NULL,
-                        OPEN_EXISTING, 0, NULL)))
+  if ((Hdl= CreateFile("CONIN$",
+                       GENERIC_READ | GENERIC_WRITE,
+                       FILE_SHARE_READ,
+                       NULL,
+                       OPEN_EXISTING, 0, NULL)) == INVALID_HANDLE_VALUE)
   {
     /* todo: provide a graphical dialog */
     return buffer;


### PR DESCRIPTION
The Windows error condition for failing to open a file is INVALID_HANDLE_VALUE is returned.