### PR TITLE
MDEV-38499: cmake and compile errors on MacOSX when compiling mariadb

### DIFF
--- a/cmake/FindGSSAPI.cmake
+++ b/cmake/FindGSSAPI.cmake
@@ -61,7 +61,12 @@ else(GSSAPI_LIBS AND GSSAPI_FLAVOR)
   if(KRB5_CONFIG)
   
     set(HAVE_KRB5_GSSAPI TRUE)
-    exec_program(${KRB5_CONFIG} ARGS --libs gssapi RETURN_VALUE _return_VALUE OUTPUT_VARIABLE GSSAPI_LIBS)
+    execute_process(
+        COMMAND ${KRB5_CONFIG} --libs gssapi
+        RESULT_VARIABLE _return_VALUE
+        OUTPUT_VARIABLE GSSAPI_LIBS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
     if(_return_VALUE)
       message(STATUS "GSSAPI configure check failed.")
       set(HAVE_KRB5_GSSAPI FALSE)
@@ -71,11 +76,20 @@ else(GSSAPI_LIBS AND GSSAPI_FLAVOR)
       string(REGEX REPLACE  "-L[A-Za-z0-9_/,:-]*[ $]?" "" GSSAPI_LIBS "${GSSAPI_LIBS}")
     ENDIF()
   
-    exec_program(${KRB5_CONFIG} ARGS --cflags gssapi RETURN_VALUE _return_VALUE OUTPUT_VARIABLE GSSAPI_INCS)
+    execute_process(
+        COMMAND ${KRB5_CONFIG} --cflags gssapi
+        RESULT_VARIABLE _return_VALUE
+        OUTPUT_VARIABLE GSSAPI_INCS
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
     string(REGEX REPLACE "(\r?\n)+$" "" GSSAPI_INCS "${GSSAPI_INCS}")
     string(REGEX REPLACE " *-I" ";" GSSAPI_INCS "${GSSAPI_INCS}")
 
-    exec_program(${KRB5_CONFIG} ARGS --vendor RETURN_VALUE _return_VALUE OUTPUT_VARIABLE gssapi_flavor_tmp)
+    execute_process(
+        COMMAND ${KRB5_CONFIG} --vendor
+        RESULT_VARIABLE _return_VALUE
+        OUTPUT_VARIABLE gssapi_flavor_tmp
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
     set(GSSAPI_FLAVOR_MIT)
     if(gssapi_flavor_tmp MATCHES ".*Massachusetts.*")
       set(GSSAPI_FLAVOR "MIT")


### PR DESCRIPTION
Replace deprecated cmake function calls to avoid warnings

Replaced the deprecated exec_program calls with exeecute_process() This removed the deprecation cmake warnings.