### PR TITLE
Fix ninja build for DEB layout

### DIFF
--- a/libmariadb/CMakeLists.txt
+++ b/libmariadb/CMakeLists.txt
@@ -490,7 +490,10 @@ IF(WITH_MYSQLCOMPAT)
   ENDIF()
 ENDIF()
 
-create_symlink(libmariadb${CMAKE_STATIC_LIBRARY_SUFFIX} mariadbclient ${INSTALL_LIBDIR})
+# In DEB layout, mariadbclient is already named libmariadb.a — skip the symlink.
+IF(NOT INSTALL_LAYOUT STREQUAL "DEB")
+  create_symlink(libmariadb${CMAKE_STATIC_LIBRARY_SUFFIX} mariadbclient ${INSTALL_LIBDIR})
+ENDIF()
 
 SET_TARGET_PROPERTIES(libmariadb PROPERTIES VERSION
  ${CPACK_PACKAGE_VERSION_MAJOR}


### PR DESCRIPTION
In DEB layout, mariadbclient is named libmariadb.a

In install.cmake:
SET(LIBMARIADB_STATIC_DEB "mariadb")

This causes a duplicate target for libmariadb.a, and moreover, a symlink recipe with reference to already existing file.

Make builds don't report a dupliate problem, and besides, "file already exists" is not reported somehow.
Ninja build reports error.

The only check that has to be done is comparison
against INSTALL_LAYOUT, because LIBMARIADB_STATIC_NAME is unconditionally set to the layout's value:
SET(LIBMARIADB_STATIC_NAME ${LIBMARIADB_STATIC_${INSTALL_LAYOUT}})