### PR TITLE
CONC-769: add NULL checks for ma_hash_new() return value

### DIFF
--- a/include/ma_crypt.h
+++ b/include/ma_crypt.h
@@ -122,18 +122,21 @@ static inline size_t ma_hash_digest_size(unsigned int hash_alg)
   @param[in] buffer_leng  length of buffer
   @param[out] digest      computed hash digest
 
-  @return                 void
+  @return                 0 on success, 1 on failure
 */
-static inline void ma_hash(unsigned int algorithm,
+static inline int ma_hash(unsigned int algorithm,
                            const unsigned char *buffer,
                            size_t buffer_length,
                            unsigned char *digest)
 {
-  MA_HASH_CTX *ctx= NULL;
+  MA_HASH_CTX *ctx;
   ctx= ma_hash_new(algorithm);
+  if (!ctx)
+    return 1;
   ma_hash_input(ctx, buffer, buffer_length);
   ma_hash_result(ctx, digest);
   ma_hash_free(ctx);
+  return 0;
 }
 
 #endif /* _ma_crypt_h_ */

--- a/include/mariadb_com.h
+++ b/include/mariadb_com.h
@@ -471,7 +471,7 @@ extern "C" {
 #endif
   
 char *ma_scramble_323(char *to,const char *message,const char *password);
-void ma_scramble_41(const unsigned char *buffer, const char *scramble, const char *password);
+int ma_scramble_41(const unsigned char *buffer, const char *scramble, const char *password);
 void ma_hash_password(unsigned long *result, const char *password, size_t len);
 void ma_make_scrambled_password(char *to,const char *password);
 

--- a/libmariadb/ma_password.c
+++ b/libmariadb/ma_password.c
@@ -98,21 +98,25 @@ void my_crypt(unsigned char *buffer, const unsigned char *s1, const unsigned cha
 	}
 }
 
-void ma_scramble_41(const unsigned char *buffer, const char *scramble, const char *password)
+int ma_scramble_41(const unsigned char *buffer, const char *scramble, const char *password)
 {
 	MA_HASH_CTX *ctx;
 	unsigned char sha1[MA_SHA1_HASH_SIZE];
 	unsigned char sha2[MA_SHA1_HASH_SIZE];
-	
+
 
 	/* Phase 1: hash password */
-  ma_hash(MA_HASH_SHA1, (unsigned char *)password, strlen(password), sha1);
+  if (ma_hash(MA_HASH_SHA1, (unsigned char *)password, strlen(password), sha1))
+    return 1;
 
 	/* Phase 2: hash sha1 */
-  ma_hash(MA_HASH_SHA1, (unsigned char *)sha1, MA_SHA1_HASH_SIZE, sha2);
+  if (ma_hash(MA_HASH_SHA1, (unsigned char *)sha1, MA_SHA1_HASH_SIZE, sha2))
+    return 1;
 
 	/* Phase 3: hash scramble + sha2 */
   ctx= ma_hash_new(MA_HASH_SHA1);
+  if (!ctx)
+    return 1;
   ma_hash_input(ctx, (unsigned char *)scramble, SCRAMBLE_LENGTH);
   ma_hash_input(ctx, (unsigned char *)sha2, MA_SHA1_HASH_SIZE);
   ma_hash_result(ctx, (unsigned char *)buffer);
@@ -120,6 +124,7 @@ void ma_scramble_41(const unsigned char *buffer, const char *scramble, const cha
 
 	/* let's crypt buffer now */
 	my_crypt((uchar *)buffer, (const unsigned char *)buffer, (const unsigned  char *)sha1, MA_SHA1_HASH_SIZE);
+	return 0;
 }
 /* }}} */
 

--- a/libmariadb/secure/schannel.c
+++ b/libmariadb/secure/schannel.c
@@ -844,6 +844,11 @@ unsigned int ma_tls_get_finger_print(MARIADB_TLS *ctls, uint hash_type, char *fp
     return 0;
 
   hash_ctx = ma_hash_new(hash_type);
+  if (!hash_ctx)
+  {
+    CertFreeCertificateContext(pRemoteCertContext);
+    return 0;
+  }
   ma_hash_input(hash_ctx, pRemoteCertContext->pbCertEncoded, pRemoteCertContext->cbCertEncoded);
   ma_hash_result(hash_ctx, (unsigned char *)fp);
   ma_hash_free(hash_ctx);

--- a/plugins/auth/ed25519.c
+++ b/plugins/auth/ed25519.c
@@ -116,7 +116,8 @@ static int auth_ed25519_client(MYSQL_PLUGIN_VIO *vio, MYSQL *mysql)
     return CR_SERVER_HANDSHAKE_ERR;
 
   /* Sign nonce: the crypto_sign function is part of ref10 */
-  ma_crypto_sign(signature, pk, packet, NONCE_BYTES, (unsigned char*)mysql->passwd, pwlen);
+  if (ma_crypto_sign(signature, pk, packet, NONCE_BYTES, (unsigned char*)mysql->passwd, pwlen))
+    return CR_ERROR;
 
   /* send signature to server */
   if (vio->write_packet(vio, signature, CRYPTO_BYTES))
@@ -138,7 +139,8 @@ static int auth_ed25519_hash(MYSQL *mysql __attribute__((unused)),
   *outlen= CRYPTO_PUBLICKEYBYTES;
 
 #ifndef HAVE_THREAD_LOCAL
-  crypto_sign_keypair(pk, (unsigned char*)mysql->passwd, strlen(mysql->passwd));
+  if (crypto_sign_keypair(pk, (unsigned char*)mysql->passwd, strlen(mysql->passwd)))
+    return 1;
 #endif
 
   /* use the cached value */

--- a/plugins/auth/my_auth.c
+++ b/plugins/auth/my_auth.c
@@ -136,7 +136,12 @@ static int native_password_auth_client(MYSQL_PLUGIN_VIO *vio, MYSQL *mysql)
   {
     char scrambled[SCRAMBLE_LENGTH + 1];
     memset(scrambled, 0, SCRAMBLE_LENGTH + 1);
-    ma_scramble_41((uchar *)scrambled, (char*)pkt, mysql->passwd);
+    if (ma_scramble_41((uchar *)scrambled, (char*)pkt, mysql->passwd))
+    {
+      SET_CLIENT_ERROR(mysql, CR_AUTH_PLUGIN_ERR, SQLSTATE_UNKNOWN,
+                       "SHA1 hash computation failed");
+      return CR_ERROR;
+    }
     if (vio->write_packet(vio, (uchar*)scrambled, SCRAMBLE_LENGTH))
       return CR_ERROR;
   }
@@ -156,9 +161,11 @@ static int native_password_hash(MYSQL *mysql, unsigned char *out, size_t *out_le
   *out_length= MA_SHA1_HASH_SIZE;
 
   /* would it be better to reuse instead of recalculating here? see ed25519 */
-  ma_hash(MA_HASH_SHA1, (unsigned char*)mysql->passwd, strlen(mysql->passwd),
-          digest);
-  ma_hash(MA_HASH_SHA1, digest, sizeof(digest), out);
+  if (ma_hash(MA_HASH_SHA1, (unsigned char*)mysql->passwd, strlen(mysql->passwd),
+              digest))
+    return 1;
+  if (ma_hash(MA_HASH_SHA1, digest, sizeof(digest), out))
+    return 1;
 
   return 0;
 }

--- a/plugins/auth/parsec.c
+++ b/plugins/auth/parsec.c
@@ -155,7 +155,10 @@ cleanup:
 #elif defined(HAVE_SCHANNEL)
   unsigned char sig[ED25519_SIG_LENGTH + CHALLENGE_SCRAMBLE_LENGTH * 2];
 
-  ma_crypto_sign((unsigned char *)sig, public_key, response, response_len, private_key, ED25519_KEY_LENGTH);
+  if (ma_crypto_sign((unsigned char *)sig, public_key,
+                     response, response_len,
+                     private_key, ED25519_KEY_LENGTH))
+    return 1;
   memcpy(signature, sig, ED25519_SIG_LENGTH);
 #endif
   return 0;

--- a/plugins/auth/ref10/keypair.c
+++ b/plugins/auth/ref10/keypair.c
@@ -11,7 +11,8 @@ int crypto_sign_keypair(
   unsigned char az[64];
   ge_p3 A;
 
-  crypto_hash_sha512(az,pw,pwlen);
+  if (crypto_hash_sha512(az,pw,pwlen))
+    return -1;
   az[0] &= 248;
   az[31] &= 63;
   az[31] |= 64;

--- a/plugins/auth/ref10/open.c
+++ b/plugins/auth/ref10/open.c
@@ -23,7 +23,8 @@ int crypto_sign_open(
   memmove(scopy,sm + 32,32);
 
   memmove(sm + 32,pk,32);
-  crypto_hash_sha512(h,sm,smlen);
+  if (crypto_hash_sha512(h,sm,smlen))
+    goto badsig;
   sc_reduce(h);
 
   ge_double_scalarmult_vartime(&R,h,&A,scopy);

--- a/plugins/auth/ref10/sign.c
+++ b/plugins/auth/ref10/sign.c
@@ -15,14 +15,16 @@ int ma_crypto_sign(
   unsigned char hram[64];
   ge_p3 A, R;
 
-  crypto_hash_sha512(az,pw,pwlen);
+  if (crypto_hash_sha512(az,pw,pwlen))
+    return -1;
   az[0] &= 248;
   az[31] &= 63;
   az[31] |= 64;
 
   memmove(sm + 64,m,mlen);
   memmove(sm + 32,az + 32,32);
-  crypto_hash_sha512(nonce,sm + 32,mlen + 32);
+  if (crypto_hash_sha512(nonce,sm + 32,mlen + 32))
+    return -1;
 
   ge_scalarmult_base(&A,az);
   ge_p3_tobytes(sm + 32,&A);
@@ -32,7 +34,8 @@ int ma_crypto_sign(
   ge_scalarmult_base(&R,nonce);
   ge_p3_tobytes(sm,&R);
 
-  crypto_hash_sha512(hram,sm,mlen + 64);
+  if (crypto_hash_sha512(hram,sm,mlen + 64))
+    return -1;
   sc_reduce(hram);
   sc_muladd(sm + 32,hram,az,nonce);
 


### PR DESCRIPTION
ma_hash_new() can return NULL when EVP_DigestInit() fails (e.g., OpenSSL provider misconfiguration, algorithm unavailable, or another library altering OpenSSL global state).

The inline ma_hash() function in ma_crypt.h and the direct call in ma_scramble_41() pass the NULL pointer to ma_hash_input(), which calls EVP_DigestUpdate(NULL, ...) and crashes with SIGSEGV.

This was reported as BZ#2361420 (DigiKam SIGSEGV via Qt QMYSQL driver) and CONC-769 (caching_sha2 auth failure against MySQL 8.0).

Fix all call sites that use ma_hash_new() or the ma_hash() inline without checking for NULL:

- ma_hash(): change return type from void to int, return 1 on failure
- ma_scramble_41(): change return type from void to int, propagate errors
- native_password_auth_client(): check ma_scramble_41() return
- native_password_hash(): check ma_hash() return
- schannel.c ma_tls_get_finger_print(): check ma_hash_new() for NULL
- ed25519 ref10 sign/keypair/open: check crypto_hash_sha512() return
- ed25519.c/parsec.c: check ma_crypto_sign()/crypto_sign_keypair() return

Note: caching_sha2_pw.c already checks ma_hash_new() correctly.