### PR TITLE
CONC-813, CONC-814 Fix UBSan errors

### DIFF
--- a/include/ma_global.h
+++ b/include/ma_global.h
@@ -832,10 +832,7 @@ do { doubleget_union _tmp; \
 				  (((uint32) (uchar) (A)[2]) << 16) |\
 				  (((uint32) (uchar) (A)[1]) << 8) | \
 				  ((uint32) (uchar) (A)[0])))
-#define sint4korr(A)	(int32) (((int32) ((uchar) (A)[0])) +\
-				(((int32) ((uchar) (A)[1]) << 8)) +\
-				(((int32) ((uchar) (A)[2]) << 16)) +\
-				(((int32) ((int16) (A)[3]) << 24)))
+#define sint4korr(A)	(int32) uint4korr(A)
 #define sint8korr(A)	(longlong) uint8korr(A)
 #define uint2korr(A)	(uint16) (((uint16) ((uchar) (A)[0])) +\
 				  ((uint16) ((uchar) (A)[1]) << 8))

--- a/libmariadb/ma_stmt_codec.c
+++ b/libmariadb/ma_stmt_codec.c
@@ -633,9 +633,16 @@ static void convert_from_long(MYSQL_BIND *r_param, const MYSQL_FIELD *field, lon
       dbl= (is_unsigned) ? ulonglong2double((ulonglong)val) : (double)val;
       doublestore(r_param->buffer, dbl);
 
-      *r_param->error = (dbl != ceil(dbl)) ||
-                         (is_unsigned ? (ulonglong )dbl != (ulonglong)val :
-                                        (longlong)dbl != (longlong)val);
+      if (dbl != ceil(dbl))
+        *r_param->error= 1;
+      else if (is_unsigned)
+        *r_param->error= dbl < 0 ||
+                          dbl >= (double)ULONGLONG_MAX ||
+                          (ulonglong)dbl != (ulonglong)val;
+      else
+        *r_param->error= dbl < (double)LONGLONG_MIN ||
+                          dbl >= (double)LONGLONG_MAX ||
+                          (longlong)dbl != (longlong)val;
 
       r_param->buffer_length= 8;
       break;
@@ -645,9 +652,18 @@ static void convert_from_long(MYSQL_BIND *r_param, const MYSQL_FIELD *field, lon
       volatile float fval;
       fval= is_unsigned ? (float)(ulonglong)(val) : (float)val;
       floatstore((uchar *)r_param->buffer, fval);
-      *r_param->error= (fval != ceilf(fval)) ||
-                        (is_unsigned ? (ulonglong)fval != (ulonglong)val :
-                                       (longlong)fval != val);
+
+      if (fval != ceilf(fval))
+        *r_param->error= 1;
+      else if (is_unsigned)
+        *r_param->error= fval < 0 ||
+                          fval >= (float)ULONGLONG_MAX ||
+                          (ulonglong)fval != (ulonglong)val;
+      else
+        *r_param->error= fval < (float)LONGLONG_MIN ||
+                          fval >= (float)LONGLONG_MAX ||
+                          (longlong)fval != val;
+
       r_param->buffer_length= 4;
     }
     break;


### PR DESCRIPTION
sint4korr (non-x86 path): the expression
`(int16)(A)[3] << 24` causes signed integer overflow when byte value >= 128, since 128<<24 exceeds INT32_MAX. Redefine as `(int32) uint4korr(A)` to compute in unsigned arithmetic, matching the server (my_byteorder.h:137-140). The next line sint8korr already uses this same pattern: `(longlong) uint8korr(A)`.

convert_from_long (MYSQL_TYPE_DOUBLE, MYSQL_TYPE_FLOAT): casting double/float back to ulonglong/longlong for truncation detection is undefined when the float value is outside the representable integer range. For example, `(double)ULONGLONG_MAX` rounds up to 2^64 in IEEE 754 (not exactly representable with 53-bit mantissa), so `(ulonglong)dbl` overflows. Similarly for LONGLONG_MAX. Add range checks before the cast using `>=` for upper bounds (since the double rounds up past the integer max) and `<` for LONGLONG_MIN (exactly representable as -2^63). Out-of-range values set the truncation error flag directly, short-circuiting the dangerous cast via `||` evaluation. This matches the server pattern in sql/field.cc and sql/sql_select.cc (double_to_ulonglong macro).