### PR TITLE
CONC-818 report CR_SERVER_LOST on TLS connection close

### DIFF
--- a/libmariadb/secure/gnutls.c
+++ b/libmariadb/secure/gnutls.c
@@ -1370,8 +1370,30 @@ ssize_t ma_tls_read(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
       break;
   }
   if (rc <= 0) {
-    MYSQL *mysql= (MYSQL *)gnutls_session_get_ptr(ctls->ssl);
-    ma_tls_set_error(mysql, ctls->ssl, rc);
+    /*
+      Peer closed the connection.  Return 0 so the caller reports
+      CR_SERVER_LOST instead of a misleading CR_SSL_CONNECTION_ERROR.
+
+      - rc == 0: orderly TLS shutdown (close_notify received).
+        Mirrors schannel.c SEC_I_CONTEXT_EXPIRED handling.
+      - GNUTLS_E_PREMATURE_TERMINATION: peer closed without
+        close_notify (GnuTLS 3.7.4+).
+      - GNUTLS_E_UNEXPECTED_PACKET_LENGTH: same condition on
+        GnuTLS < 3.7.4 (min required version is 3.5).
+    */
+    if (rc == 0
+#ifdef GNUTLS_E_PREMATURE_TERMINATION
+        || rc == GNUTLS_E_PREMATURE_TERMINATION
+#endif
+#ifdef GNUTLS_E_UNEXPECTED_PACKET_LENGTH
+        || rc == GNUTLS_E_UNEXPECTED_PACKET_LENGTH
+#endif
+       )
+      return 0;
+    {
+      MYSQL *mysql= (MYSQL *)gnutls_session_get_ptr(ctls->ssl);
+      ma_tls_set_error(mysql, ctls->ssl, rc);
+    }
   }
   return rc;
 }

--- a/libmariadb/secure/openssl.c
+++ b/libmariadb/secure/openssl.c
@@ -719,8 +719,35 @@ ssize_t ma_tls_read(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
   int rc= SSL_read((SSL *)ctls->ssl, (void *)buffer, (int)length);
   if (rc <= 0)
   {
-    MYSQL *mysql= SSL_get_app_data(ctls->ssl);
-    ma_tls_set_error(mysql);
+    int error= SSL_get_error((SSL *)ctls->ssl, rc);
+    /*
+      Peer closed the connection.  Return 0 so the caller reports
+      CR_SERVER_LOST instead of a misleading CR_SSL_CONNECTION_ERROR.
+
+      - SSL_ERROR_ZERO_RETURN: orderly TLS shutdown (close_notify
+        received).  Mirrors schannel.c SEC_I_CONTEXT_EXPIRED handling.
+      - SSL_ERROR_SYSCALL with empty error queue: unexpected EOF
+        without close_notify (OpenSSL 1.x).
+      - SSL_ERROR_SSL with SSL_R_UNEXPECTED_EOF_WHILE_READING:
+        same EOF, reported differently by OpenSSL 3.x.
+    */
+    if (error == SSL_ERROR_ZERO_RETURN)
+      return 0;
+    if (error == SSL_ERROR_SYSCALL && !ERR_peek_error())
+      return 0;
+#ifdef SSL_R_UNEXPECTED_EOF_WHILE_READING
+    if (error == SSL_ERROR_SSL &&
+        ERR_GET_REASON(ERR_peek_error()) ==
+          SSL_R_UNEXPECTED_EOF_WHILE_READING)
+    {
+      ERR_clear_error();
+      return 0;
+    }
+#endif
+    {
+      MYSQL *mysql= SSL_get_app_data(ctls->ssl);
+      ma_tls_set_error(mysql);
+    }
   }
   return rc;
 }


### PR DESCRIPTION
When the server closes a connection, ma_tls_read() in the OpenSSL and GnuTLS plugins unconditionally calls
ma_tls_set_error(), which sets CR_SSL_CONNECTION_ERROR. The caller ma_net_safe_read() then preserves that error code instead of reporting the correct CR_SERVER_LOST.

The Schannel plugin already handles this correctly: it returns 0 on SEC_I_CONTEXT_EXPIRED without setting any TLS error (schannel.c:640-642).

Apply the same logic to OpenSSL and GnuTLS.  Detect connection close and return 0 without setting error:

OpenSSL:
- SSL_ERROR_ZERO_RETURN: orderly close (close_notify)
- SSL_ERROR_SYSCALL with empty error queue: EOF without close_notify (OpenSSL 1.x)
- SSL_ERROR_SSL with SSL_R_UNEXPECTED_EOF_WHILE_READING: same EOF, reported differently by OpenSSL 3.x

GnuTLS:
- rc == 0: orderly close (close_notify)
- GNUTLS_E_PREMATURE_TERMINATION: EOF without close_notify (GnuTLS 3.7.4+)

---

Related to https://github.com/MariaDB/server/pull/4929