### PR TITLE
CONC-830: add missing MARIADB_CLIENT_PLUGIN_EXPORT to zstd plugin

### DIFF
--- a/plugins/compress/c_zstd.c
+++ b/plugins/compress/c_zstd.c
@@ -106,7 +106,7 @@ my_bool ma_zstd_decompress(ma_compress_ctx *ctx, void *dst, size_t *dst_len,
 #ifndef PLUGIN_DYNAMIC
 MARIADB_COMPRESSION_PLUGIN zstd_client_plugin=
 #else
-MARIADB_COMPRESSION_PLUGIN _mysql_client_plugin_declaration_ =
+MARIADB_CLIENT_PLUGIN_EXPORT MARIADB_COMPRESSION_PLUGIN _mysql_client_plugin_declaration_ =
 #endif
 {
   MARIADB_CLIENT_COMPRESSION_PLUGIN,


### PR DESCRIPTION
MDEV-37527 added '-fvisibility=hidden' for plugin builds and the 'MARIADB_CLIENT_PLUGIN_EXPORT' macro to explicitly export '_mysql_client_plugin_declaration_' from each plugin. The zstd compression plugin was missed, leaving it with zero exported symbols and making it impossible to load dynamically via 'dlsym()'.