### PR TITLE
Use correct strncat size argument in map_charset_name() to conform to…

### DIFF
--- a/libmariadb/ma_charset.c
+++ b/libmariadb/ma_charset.c
@@ -1538,7 +1538,7 @@ static void map_charset_name(const char *cs_name, my_bool target_cs, char *buffe
 
   if (target_cs)
   {
-    strncat(buffer, "//TRANSLIT", buff_len - strlen(buffer));
+    strncat(buffer, "//TRANSLIT", buff_len - strlen(buffer) - 1);
   }
 }
 /* }}} */


### PR DESCRIPTION
**Problem**

In `libmariadb/ma_charset.c`, `map_charset_name()` calls:

```c
strncat(buffer, "//TRANSLIT", buff_len - strlen(buffer));
```

`strncat(dest, src, n)` copies at most `n` bytes from `src`, then **unconditionally appends a terminating NUL**, so `dest` must have room for `strlen(dest) + min(n, strlen(src)) + 1` bytes. The correct size argument should be `buff_len - strlen(buffer) - 1`.

The current usage does not conform to the standard semantics of `strncat`, and in theory, when `strlen(buffer) >= 118`, the terminating NUL would be written one byte past the end of the 128-byte stack buffer in `mariadb_convert_string()`.

**Note:** This does not affect the default Linux build. `WITH_ICONV` defaults to `OFF` and `FindIconv.cmake` cannot find a standalone `libiconv.so` on glibc-based systems, so `HAVE_ICONV` is not defined and this code path is not compiled in by default. However, builds on other platforms (e.g. macOS) or environments with a standalone `libiconv` installed may be affected.

Although the practical impact is limited, this fix is recommended from a code correctness and robustness perspective:

- The `strncat` usage does not conform to its standard semantics regardless of build configuration.
- The fix has zero functional impact on existing behavior.
- It prevents potential issues in downstream projects or alternative build environments where `HAVE_ICONV` is enabled.
- The change is a single character and trivially verifiable.

**Fix**

```c
- strncat(buffer, "//TRANSLIT", buff_len - strlen(buffer));
+ strncat(buffer, "//TRANSLIT", buff_len - strlen(buffer) - 1);
```

`strlen(buffer)` is guaranteed `<= buff_len - 1` by both preceding branches (`snprintf` and `strncpy` + explicit termination), so the subtraction cannot underflow.